### PR TITLE
More robust `Data` implementation

### DIFF
--- a/hayro-syntax/src/util.rs
+++ b/hayro-syntax/src/util.rs
@@ -1,5 +1,6 @@
 use log::error;
 use std::ops::Sub;
+use std::sync::OnceLock;
 
 pub(crate) trait OptionLog {
     fn error_none(self, f: &str) -> Self;
@@ -33,5 +34,77 @@ impl FloatExt for f32 {
         debug_assert!(tolerance >= 0.0, "tolerance must be positive");
 
         self.abs() <= tolerance
+    }
+}
+
+/// Allows to store elements at an index with an `&self` reference.
+///
+/// This is similar to a thread-safe arena data structure, but with less moving
+/// parts and no unsafe code. It's based on the segment list presented in
+/// <https://matklad.github.io/2023/04/23/data-oriented-parallel-value-interner.html>
+///
+/// Indices should be used in order. Usage of higher indices implies more memory
+/// usage (even if lower indices are not in use).
+///
+/// The capacity is limited at 2^C - 1. Calling `get_or_init` with a higher
+/// index will lead to a panic.
+pub(crate) struct SegmentList<T, const C: usize>([OnceLock<Box<[OnceLock<T>]>>; C]);
+
+impl<T, const C: usize> SegmentList<T, C> {
+    pub fn new() -> Self {
+        Self(std::array::from_fn(|_| OnceLock::new()))
+    }
+
+    pub fn get(&self, i: usize) -> Option<&T> {
+        let (s, k) = self.locate(i);
+        let segment = self.0[s as usize].get()?;
+        segment.get(k)?.get()
+    }
+
+    #[track_caller]
+    pub fn get_or_init(&self, i: usize, f: impl FnOnce() -> T) -> &T {
+        let (s, k) = self.locate(i);
+        let segment = self
+            .0
+            .get(s as usize)
+            .expect("segment list is out of capacity")
+            .get_or_init(|| {
+                (0..2usize.pow(s))
+                    .map(|_| OnceLock::new())
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice()
+            });
+        segment[k].get_or_init(f)
+    }
+
+    fn locate(&self, i: usize) -> (u32, usize) {
+        let power = (i + 2).next_power_of_two() / 2;
+        let s = power.trailing_zeros();
+        let k = i - ((1 << s) - 1);
+        (s, k)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segment_list() {
+        let e = SegmentList::<String, 10>::new();
+
+        // Ensure that it works.
+        for i in 0..500 {
+            e.get_or_init(i, || format!("{i}"));
+        }
+        for i in 0..500 {
+            assert_eq!(e.get(i), Some(&format!("{i}")));
+        }
+
+        // Ensure that all slots in the first 8 segments are actually in use,
+        // i.e. we didn't overallocate.
+        for s in 0..8 {
+            assert!(e.0[s].get().unwrap().iter().all(|s| s.get().is_some()))
+        }
     }
 }


### PR DESCRIPTION
This makes a few improvements to the `Data` struct:

- The old implementation was slightly race as the atomic counter was first read and then updated separately. This could lead to two object streams sharing the same decoded data even though they are different (at least if that API is called from multiple threads). I replaced the `AtomicUsize` with just using the length of the hash map to count up and since that is protected by the Mutex, the raciness should be fixed.

- The old implementation was limited to 10,000 objects and preallocated 320KB to support this, which is a bit unfortunate. The easiest way to get the desired lifetimes would have been to introduce unsafe code (as the data doesn't actually move), but I wanted to avoid this. Another possible choice would be to use a thread-safe arena implementation, but I don't know of a good one and this would've also introduced a dependency. So what I've opted for instead is a simpler data structure with less moving parts that I first learned about in [this blog post by matklad](https://matklad.github.io/2023/04/23/data-oriented-parallel-value-interner.html). It's essentially an array of lazily initialized arrays of lengths that double in size every time. The top-level array can have statically known size because 2^31-1 is enough space.

I added a test for the new data structure, but couldn't check whether the `Data` struct still works correctly as the tests don't really work on my system. I ran `get_tests.py` to get the downloads, but a lot of tests just fail on master.