### PR TITLE
Fix minimum version of `kurbo` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = { version = "2.9" }
 bytemuck = { version = "1" }
 image = { version = "0.25", default-features = false }
 jpeg2k = { version = "0.10", default-features = false, features = ["openjp2"] }
-kurbo = { version = "0.11" }
+kurbo = { version = "0.11.2" }
 log = { version = "0.4" }
 resvg = { version = "0.45.1" }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }


### PR DESCRIPTION
Hayro uses kurbo 0.11.2 features. With the current imprecise bound, projects with a lockfile containing a kurbo version >=0.11.0 but <0.11.2 will get a compiler error.