### PR TITLE
feat: update pdf-writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,8 +819,7 @@ dependencies = [
 [[package]]
 name = "pdf-writer"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea27c5015ab81753fc61e49f8cde74999346605ee148bb20008ef3d3150e0dc"
+source = "git+https://github.com/typst/pdf-writer?rev=143a1c3#143a1c3543a1422a22bda40a68022d0d9ad3a40e"
 dependencies = [
  "bitflags 2.9.1",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ siphasher = "1"
 skrifa = { version = "0.32" }
 smallvec = { version = "1" }
 yoke = { version = "0.8" }
-pdf-writer = "0.13"
+pdf-writer = { git = "https://github.com/typst/pdf-writer", rev = "143a1c3" }
 sitro = { git = "https://github.com/LaurenzV/sitro", rev="fb804b3" }
 xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }


### PR DESCRIPTION
This should stay a draft until the accompanying PR in krilla is ready to get merged. In case `pdf-writer` needs to be updated again.