### PR TITLE
Replace `qcms` with `moxcms`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,8 +326,8 @@ dependencies = [
  "image 0.25.6",
  "kurbo",
  "log",
+ "moxcms",
  "phf",
- "qcms",
  "rustc-hash",
  "siphasher",
  "skrifa",
@@ -535,6 +535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,10 +654,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "qcms"
-version = "0.3.0"
+name = "pxfm"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
+checksum = "376f733579ac4d3b9fbf0afca99bf8f6b698d541118affca554d0b86f73c2470"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "qoi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resvg = { version = "0.45.1" }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 once_cell = { version = "1" }
 phf = { version = "0.11" }
-qcms = { version = "0.3" }
+moxcms = { version = "0.7.5" }
 rustc-hash = { version = "2" }
 siphasher = "1"
 skrifa = { version = "0.33" }

--- a/hayro-interpret/Cargo.toml
+++ b/hayro-interpret/Cargo.toml
@@ -11,7 +11,7 @@ hayro-syntax = { workspace = true }
 kurbo = { workspace = true }
 smallvec = { workspace = true }
 log = { workspace = true }
-qcms =  { workspace = true }
+moxcms = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 skrifa = { workspace = true }
 yoke = { workspace = true, features = ["derive"]}

--- a/hayro-interpret/src/color.rs
+++ b/hayro-interpret/src/color.rs
@@ -10,11 +10,11 @@ use hayro_syntax::object::Object;
 use hayro_syntax::object::Stream;
 use hayro_syntax::object::dict::keys::*;
 use log::warn;
+use moxcms::{ColorProfile, DataColorSpace, Layout, Transform8BitExecutor, TransformOptions};
 use smallvec::{SmallVec, ToSmallVec, smallvec};
 use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock};
-use moxcms::{ColorProfile, DataColorSpace, Layout, Transform8BitExecutor, TransformOptions};
 
 /// A storage for the components of colors.
 pub type ColorComponents = SmallVec<[f32; 4]>;
@@ -764,12 +764,12 @@ impl Debug for ICCProfile {
 impl ICCProfile {
     fn new(profile: &[u8], number_components: usize) -> Option<Self> {
         let src_profile = ColorProfile::new_from_slice(profile).ok()?;
-        
+
         // Temporary workaround as 3 PDFs don't render correctly without this.
         if src_profile.color_space == DataColorSpace::Lab {
             return None;
         }
-        
+
         let dest_profile = ColorProfile::new_srgb();
 
         let src_layout = match number_components {
@@ -784,7 +784,12 @@ impl ICCProfile {
         };
 
         let transform = src_profile
-            .create_transform_8bit(src_layout, &dest_profile, Layout::Rgb, TransformOptions::default())
+            .create_transform_8bit(
+                src_layout,
+                &dest_profile,
+                Layout::Rgb,
+                TransformOptions::default(),
+            )
             .ok()?;
 
         Some(Self(Arc::new(ICCColorRepr {
@@ -819,7 +824,8 @@ impl ICCProfile {
                 &mut srgb,
             ),
             _ => return None,
-        }.ok()?;
+        }
+        .ok()?;
 
         Some(srgb)
     }

--- a/hayro-interpret/src/color.rs
+++ b/hayro-interpret/src/color.rs
@@ -10,11 +10,11 @@ use hayro_syntax::object::Object;
 use hayro_syntax::object::Stream;
 use hayro_syntax::object::dict::keys::*;
 use log::warn;
-use qcms::Transform;
 use smallvec::{SmallVec, ToSmallVec, smallvec};
 use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock};
+use moxcms::{ColorProfile, DataColorSpace, Layout, Transform8BitExecutor, TransformOptions};
 
 /// A storage for the components of colors.
 pub type ColorComponents = SmallVec<[f32; 4]>;
@@ -748,7 +748,7 @@ impl DeviceN {
 }
 
 struct ICCColorRepr {
-    transform: Transform,
+    transform: Box<Transform8BitExecutor>,
     number_components: usize,
 }
 
@@ -763,14 +763,19 @@ impl Debug for ICCProfile {
 
 impl ICCProfile {
     fn new(profile: &[u8], number_components: usize) -> Option<Self> {
-        let input = qcms::Profile::new_from_slice(profile, false)?;
-        let mut output = qcms::Profile::new_sRGB();
-        output.precache_output_transform();
+        let src_profile = ColorProfile::new_from_slice(profile).ok()?;
+        
+        // Temporary workaround as 3 PDFs don't render correctly without this.
+        if src_profile.color_space == DataColorSpace::Lab {
+            return None;
+        }
+        
+        let dest_profile = ColorProfile::new_srgb();
 
-        let data_type = match number_components {
-            1 => qcms::DataType::Gray8,
-            3 => qcms::DataType::RGB8,
-            4 => qcms::DataType::CMYK,
+        let src_layout = match number_components {
+            1 => Layout::Gray,
+            3 => Layout::Rgb,
+            4 => Layout::Rgba,
             _ => {
                 warn!("unsupported number of components {number_components} for ICC profile");
 
@@ -778,13 +783,9 @@ impl ICCProfile {
             }
         };
 
-        let transform = Transform::new_to(
-            &input,
-            &output,
-            data_type,
-            qcms::DataType::RGB8,
-            qcms::Intent::default(),
-        )?;
+        let transform = src_profile
+            .create_transform_8bit(src_layout, &dest_profile, Layout::Rgb, TransformOptions::default())
+            .unwrap();
 
         Some(Self(Arc::new(ICCColorRepr {
             transform,
@@ -799,8 +800,8 @@ impl ICCProfile {
             1 => self
                 .0
                 .transform
-                .convert(&[f32_to_u8(*c.first()?)], &mut srgb),
-            3 => self.0.transform.convert(
+                .transform(&[f32_to_u8(*c.first()?)], &mut srgb),
+            3 => self.0.transform.transform(
                 &[
                     f32_to_u8(*c.first()?),
                     f32_to_u8(*c.get(1)?),
@@ -808,7 +809,7 @@ impl ICCProfile {
                 ],
                 &mut srgb,
             ),
-            4 => self.0.transform.convert(
+            4 => self.0.transform.transform(
                 &[
                     f32_to_u8(*c.first()?),
                     f32_to_u8(*c.get(1)?),
@@ -818,7 +819,7 @@ impl ICCProfile {
                 &mut srgb,
             ),
             _ => return None,
-        }
+        }.ok()?;
 
         Some(srgb)
     }

--- a/hayro-interpret/src/color.rs
+++ b/hayro-interpret/src/color.rs
@@ -785,7 +785,7 @@ impl ICCProfile {
 
         let transform = src_profile
             .create_transform_8bit(src_layout, &dest_profile, Layout::Rgb, TransformOptions::default())
-            .unwrap();
+            .ok()?;
 
         Some(Self(Arc::new(ICCColorRepr {
             transform,


### PR DESCRIPTION
This crate is now used by the `image` crate, seems to have better performance, be better maintained, has less unsafe and also supports transform with f32, which might come in handy in the future.