### PR TITLE
Revert "Guard against stack overflows in indirect object resolving (#…

### DIFF
--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -341,7 +341,6 @@ impl XRef {
 
         let mut ctx = ctx.clone();
         ctx.in_content_stream = false;
-        ctx.parent_chain.push(id);
 
         match entry {
             EntryType::Normal(offset) => {

--- a/hayro-tests/pdfs/load/issue273_180b.pdf
+++ b/hayro-tests/pdfs/load/issue273_180b.pdf
@@ -1,5 +1,0 @@
-
-1 0obj<</Filter/Fl/First 43/N 6/Type/ObjStm>>
-stream
-}ÁjÃ0†_E·¶ì`Ùsºdš0(£,t=B^"J
-‹í@÷ö““Ã`‡	Œ,ñ²~g€ğR!ä 3ÈBƒ…|@Ó<</t 2/Root 10 0R/Size[1]>>10 0obj<</Pages 2 0R>>endstream

--- a/hayro-tests/tests/load.rs
+++ b/hayro-tests/tests/load.rs
@@ -175,12 +175,6 @@ fn issue236() {
 }
 
 #[test]
-fn issue273_180b() {
-    let file = include_bytes!("../pdfs/load/issue273_180b.pdf");
-    load(file);
-}
-
-#[test]
 fn issue323() {
     let file = include_bytes!("../pdfs/load/issue323.pdf");
     load(file);


### PR DESCRIPTION
…347)"

This reverts commit 2eea790de148be039241c14d678d4c5e5fdd1f6e.