### PR TITLE
hayro-syntax: Don't try to decode a stream when doing fallback parsing

### DIFF
--- a/hayro-syntax/src/object/stream.rs
+++ b/hayro-syntax/src/object/stream.rs
@@ -11,7 +11,7 @@ use crate::object::{Object, ObjectLike};
 use crate::reader::Reader;
 use crate::reader::{Readable, ReaderContext, ReaderExt, Skippable};
 use crate::util::OptionLog;
-use log::{info, warn};
+use log::warn;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};


### PR DESCRIPTION
Otherwise this might take prohibitively long for large PDFs with invalid xref tables.