### PR TITLE
hayro-interpret: fix skrifa traversal feature

### DIFF
--- a/hayro-interpret/src/util.rs
+++ b/hayro-interpret/src/util.rs
@@ -36,8 +36,7 @@ impl CodeMapExt for CmapSubtable<'_> {
             CmapSubtable::Format6(f) => f.map_codepoint(code),
             CmapSubtable::Format12(f) => f.map_codepoint(code),
             _ => {
-                warn!("unsupported cmap table {self:?}");
-
+                warn!("unsupported cmap table");
                 None
             }
         }


### PR DESCRIPTION
Skrifa un-defaulted the traversal feature in https://github.com/googlefonts/fontations/pull/1666 and released the change in a new _patch_ version (0.35.1), a most peculiar decision. 

Nevertheless, `hayro-interpret` now fails to compile as `CmapSubtable` no longer implements `Debug`, hence removed from formatting.