### PR TITLE
hayro-jpeg2000: Fix two issues in an openjpeg image

### DIFF
--- a/hayro-jpeg2000/src/decode.rs
+++ b/hayro-jpeg2000/src/decode.rs
@@ -1113,6 +1113,9 @@ fn apply_mct(tile_ctx: &mut TileDecodeContext) {
 }
 
 fn store<'a>(tile: &'a Tile<'a>, header: &Header, tile_ctx: &mut TileDecodeContext<'a>) {
+    let width = header.size_data.tile_width;
+    let height = header.size_data.tile_height;
+
     for ((idwt_output, component_info), channel_data) in tile_ctx
         .idwt_outputs
         .iter_mut()
@@ -1181,14 +1184,15 @@ fn store<'a>(tile: &'a Tile<'a>, header: &Header, tile_ctx: &mut TileDecodeConte
                     let sample = idwt_output.coefficients
                         [relative_y * component_tile.rect.width() as usize + relative_x];
 
-                    for x_offset in 0..scale_x as u32 {
-                        for y_offset in 0..scale_y as u32 {
-                            let y_position = (reference_grid_y + y_offset) as usize;
-                            let x_position = (reference_grid_x + x_offset) as usize;
+                    for x_position in
+                        reference_grid_x..u32::min(reference_grid_x + scale_x as u32, width)
+                    {
+                        for y_position in
+                            reference_grid_y..u32::min(reference_grid_y + scale_y as u32, height)
+                        {
+                            let pos = y_position as usize * width as usize + x_position as usize;
 
-                            channel_data.container[y_position
-                                * header.size_data.reference_grid_width as usize
-                                + x_position] = sample;
+                            channel_data.container[pos] = sample;
                         }
                     }
                 }

--- a/hayro-jpeg2000/src/tile.rs
+++ b/hayro-jpeg2000/src/tile.rs
@@ -180,10 +180,13 @@ fn parse_tile_part<'a>(
                         .ok_or("failed to read COC marker")?;
 
                 if first {
-                    tile.component_infos
+                    let old = tile
+                        .component_infos
                         .get_mut(component_index as usize)
-                        .ok_or("invalid component index in tile-part header")?
-                        .coding_style = coc;
+                        .ok_or("invalid component index in tile-part header")?;
+
+                    old.coding_style.parameters = coc.parameters;
+                    old.coding_style.flags.raw |= coc.flags.raw;
                 } else {
                     warn!("encountered unexpected COC marker in tile-part header");
                 }

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -1161,6 +1161,10 @@
     "link": true
   },
   {
+    "id": "openjpeg_Bretagne2_2",
+    "link": true
+  },
+  {
     "id": "issue494",
     "link": true
   }

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -284,6 +284,7 @@ use crate::run_render_test;
 #[test] fn openjpeg_Cevennes1() { run_render_test("openjpeg_Cevennes1", "downloads/custom/openjpeg_Cevennes1.pdf", None); }
 #[test] fn openjpeg_Cevennes2() { run_render_test("openjpeg_Cevennes2", "downloads/custom/openjpeg_Cevennes2.pdf", None); }
 #[test] fn openjpeg_Rome() { run_render_test("openjpeg_Rome", "downloads/custom/openjpeg_Rome.pdf", None); }
+#[test] fn openjpeg_Bretagne2_2() { run_render_test("openjpeg_Bretagne2_2", "downloads/custom/openjpeg_Bretagne2_2.pdf", None); }
 #[test] fn issue494() { run_render_test("issue494", "downloads/custom/issue494.pdf", None); }
 #[test] fn pdfjs_20130226130259() { run_render_test("pdfjs_20130226130259", "downloads/pdfjs/20130226130259.pdf", Some("0..=0")); }
 #[test] fn pdfjs_ContentStreamNoCycleType3insideType3() { run_render_test("pdfjs_ContentStreamNoCycleType3insideType3", "downloads/pdfjs/ContentStreamNoCycleType3insideType3.pdf", None); }


### PR DESCRIPTION
The first bug was an issue where we didn't properly propagate code style flags from the main header. The second part was an OOB access which can happen if we have an unlucky combination of scale factor + size.