### PR TITLE
hayro-syntax: fix unsound self-referential struct that causes memory leak

### DIFF
--- a/hayro-syntax/src/page.rs
+++ b/hayro-syntax/src/page.rs
@@ -519,7 +519,6 @@ pub(crate) mod cached {
     use crate::page::Pages;
     use crate::reader::ReaderContext;
     use crate::xref::XRef;
-    use std::ops::Deref;
     use std::sync::Arc;
 
     pub(crate) struct CachedPages {
@@ -538,7 +537,7 @@ pub(crate) mod cached {
             //     duration.
             // - The internal 'static lifetime is not leaked because its rewritten
             //   to the self-lifetime in `pages()`.
-            let xref_reference: &'static XRef = unsafe { std::mem::transmute(xref.deref()) };
+            let xref_reference: &'static XRef = unsafe { &*Arc::as_ptr(&xref) };
 
             let ctx = ReaderContext::new(xref_reference, false);
             let pages = xref_reference


### PR DESCRIPTION
I was testing this library using my project [Lej77/pdf-reader-gpui](https://github.com/Lej77/pdf-reader-gpui/tree/debug-memory-leak) and I noticed that it was leaking memory. I tracked it down to the [one case of unsafe code in the `hayro-syntax` crate](https://github.com/LaurenzV/hayro/blob/b239862e157fef9f4568a95fa036e65284b6022d/hayro-syntax/src/page.rs#L541) so hopefully this PR should fix it. Since self-referential structs are tricky in general it might be worth considering one of the popular crates that implement them to be more sure of the code's soundness.