### PR TITLE
Change background rasterization color from white to transparent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "hayro",
  "js-sys",
  "log",
+ "vello_cpu",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/hayro-demo/Cargo.toml
+++ b/hayro-demo/Cargo.toml
@@ -18,6 +18,7 @@ console_error_panic_hook = "0.1.7"
 log = "0.4"
 bytemuck = "1.14"
 hayro = { workspace = true, features = ["embed-fonts"]}
+vello_cpu = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/hayro-demo/src/lib.rs
+++ b/hayro-demo/src/lib.rs
@@ -2,6 +2,7 @@ use console_error_panic_hook;
 use hayro::{FontQuery, InterpreterSettings, Pdf, RenderSettings};
 use js_sys;
 use std::sync::Arc;
+use vello_cpu::color::palette::css::WHITE;
 use wasm_bindgen::prelude::*;
 
 struct ConsoleLogger;
@@ -118,6 +119,7 @@ impl PdfViewer {
         let render_settings_base = RenderSettings {
             x_scale: 1.0,
             y_scale: 1.0,
+            bg_color: WHITE,
             ..Default::default()
         };
         let base_pixmap = hayro::render(page, &interpreter_settings, &render_settings_base);
@@ -136,6 +138,7 @@ impl PdfViewer {
         let render_settings = RenderSettings {
             x_scale: scale,
             y_scale: scale,
+            bg_color: WHITE,
             ..Default::default()
         };
 

--- a/hayro/examples/render.rs
+++ b/hayro/examples/render.rs
@@ -3,6 +3,7 @@
 use hayro::{Pdf, RenderSettings, render};
 use hayro_interpret::InterpreterSettings;
 use std::sync::Arc;
+use vello_cpu::color::palette::css::WHITE;
 
 fn main() {
     if let Ok(()) = log::set_logger(&LOGGER) {
@@ -27,6 +28,7 @@ fn main() {
     let render_settings = RenderSettings {
         x_scale: scale,
         y_scale: scale,
+        bg_color: WHITE,
         ..Default::default()
     };
 

--- a/hayro/src/lib.rs
+++ b/hayro/src/lib.rs
@@ -50,6 +50,7 @@ pub use vello_cpu::Pixmap;
 use vello_cpu::color::AlphaColor;
 use vello_cpu::color::Srgb;
 use vello_cpu::color::palette::css::TRANSPARENT;
+use vello_cpu::color::palette::css::WHITE;
 use vello_cpu::{Level, RenderMode};
 
 mod renderer;
@@ -67,7 +68,7 @@ pub struct RenderSettings {
     /// The height of the viewport. If this is set to `None`, the height will be chosen
     /// automatically based on the scale factor and the dimensions of the PDF.
     pub height: Option<u16>,
-    /// The background rasterization color. Determines the color of the base
+    /// The background color. Determines the color of the base
     /// rectangle during rendering to a pixmap.
     pub bg_color: AlphaColor<Srgb>,
 }
@@ -161,6 +162,7 @@ pub fn render_pdf(
                 &RenderSettings {
                     x_scale: scale,
                     y_scale: scale,
+                    bg_color: WHITE,
                     ..Default::default()
                 },
             );


### PR DESCRIPTION
I think this is the necessary fix for https://github.com/typst/typst/issues/7235.

Correct me if I am wrong but it seems like this rectangle is the base layer for all rasterization efforts and hence, if no draw operation occurs over it, the white background persists.

I didn't want to remove the rectangle entirely since its existence might have other reasons but it seems like just changing the initial color should work.