### PR TITLE
hayro-interpret: Ensure that cmaps only contain ASCII characters

### DIFF
--- a/hayro-interpret/src/font/cmap.rs
+++ b/hayro-interpret/src/font/cmap.rs
@@ -581,6 +581,10 @@ fn parse_cmap_name(cmap: &mut CMap, lexer: &mut CMapLexer) -> Option<()> {
 }
 
 pub fn parse_cmap(input: &str) -> Option<CMap> {
+    if !input.is_ascii() {
+        return None;
+    }
+
     let mut cmap = CMap::new();
     let mut lexer = CMapLexer::new(input);
 

--- a/hayro-tests/pdfs/load/issue538.pdf
+++ b/hayro-tests/pdfs/load/issue538.pdf
@@ -1,0 +1,15 @@
+4%ß
+ 0 obj
+<</Type/Catalog/Pages 2 0R0/Contents 5 0R///Resources 6 0 R
+/T Pg>>n5 0obj
+<</Filter /FlateDecode
+L >>
+streamxœ¥VMoã6½ûWèHb!Fü&Ñ[ÑmQt»€o»=(¶+K^KŞ ıõRŠŒ)Ğ"L‡o†æ€ıq»¹»·ªDk‹ícrZ6 0 obj<<
+
+/Font <<0
+/F52 11 0R>>>>11 0 obj<</Subtype/TrueType
+/ToUnicode 46 0R
+>>
+46 0 obj<</Filter[/Fl]>>
+stream]Áj0†ï~
+[8I/„Àh)ø°­¬;ìêØJ0$²qœCm‡>Ò^a¶×ämøÏ÷ıaendstream

--- a/hayro-tests/tests/load.rs
+++ b/hayro-tests/tests/load.rs
@@ -321,6 +321,12 @@ fn issue520() {
 }
 
 #[test]
+fn issue538() {
+    let file = include_bytes!("../pdfs/load/issue538.pdf");
+    load(file);
+}
+
+#[test]
 fn page_tree_cycle() {
     let file = include_bytes!("../pdfs/load/page_tree_cycle.pdf");
     load(file);


### PR DESCRIPTION
Closes #538.