### PR TITLE
hayro-interpret: Properly support DeviceN color spaces with all `None` colorants

### DIFF
--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -1099,5 +1099,9 @@
   {
     "id": "separation_none",
     "file": "pdfs/custom/separation_none.pdf"
+  },
+  {
+    "id": "devicen_none",
+    "file": "pdfs/custom/devicen_none.pdf"
   }
 ]

--- a/hayro-tests/pdfs/custom/devicen_none.pdf
+++ b/hayro-tests/pdfs/custom/devicen_none.pdf
@@ -1,0 +1,81 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+/ColorSpace <<
+/CS1 6 0 R
+>>
+>>
+/MediaBox [ 0.0 0.0 200 200 ]
+/Parent 2 0 R
+/Contents 7 0 R
+>>
+endobj
+5 0 obj
+<<
+/FunctionType 2
+/Domain [ 0.0 1 ]
+/C0 [ 0.0 0.0 0.0 0.0 ]
+/C1 [ 0.0 0.0 0.0 1 ]
+/N 1
+>>
+endobj
+6 0 obj
+[ /DeviceN [ /None ] /DeviceCMYK 5 0 R ]
+endobj
+7 0 obj
+<<
+/Length 61
+>>
+stream
+q
+/CS1 cs
+1 scn
+0 0 200 200 re
+f
+0 0 0 RG
+0 0 200 200 re
+S
+Q
+
+endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000113 00000 n 
+0000000162 00000 n 
+0000000301 00000 n 
+0000000407 00000 n 
+0000000463 00000 n 
+trailer
+<<
+/Size 8
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+574
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -269,6 +269,7 @@ use crate::run_render_test;
 #[test] fn issue_typst_7269() { run_render_test("issue_typst_7269", "downloads/custom/issue_typst_7269.pdf", None); }
 #[test] fn image_lab_2() { run_render_test("image_lab_2", "pdfs/custom/image_lab_2.pdf", None); }
 #[test] fn separation_none() { run_render_test("separation_none", "pdfs/custom/separation_none.pdf", None); }
+#[test] fn devicen_none() { run_render_test("devicen_none", "pdfs/custom/devicen_none.pdf", None); }
 #[test] fn pdfjs_20130226130259() { run_render_test("pdfjs_20130226130259", "downloads/pdfjs/20130226130259.pdf", Some("0..=0")); }
 #[test] fn pdfjs_ContentStreamNoCycleType3insideType3() { run_render_test("pdfjs_ContentStreamNoCycleType3insideType3", "downloads/pdfjs/ContentStreamNoCycleType3insideType3.pdf", None); }
 #[test] fn pdfjs_High_Pressure_Measurement_WP_001287() { run_render_test("pdfjs_High_Pressure_Measurement_WP_001287", "downloads/pdfjs/High-Pressure-Measurement-WP-001287.pdf", Some("2..=2")); }


### PR DESCRIPTION
Closes #4.