### PR TITLE
hayro-interpret: Prevent overflow in cmap parser

### DIFF
--- a/hayro-interpret/src/font/cmap.rs
+++ b/hayro-interpret/src/font/cmap.rs
@@ -66,7 +66,7 @@ impl CMap {
     }
 
     fn map_cid_range(&mut self, low: u32, high: u32, dst_low: u32) -> Option<()> {
-        if high - low > MAX_MAP_RANGE {
+        if high.checked_sub(low)? > MAX_MAP_RANGE {
             return None;
         }
 
@@ -82,7 +82,7 @@ impl CMap {
     }
 
     fn map_bf_range(&mut self, low: u32, high: u32, dst_low: u32) -> Option<()> {
-        if high - low > MAX_MAP_RANGE {
+        if high.checked_sub(low)? > MAX_MAP_RANGE {
             return None;
         }
 
@@ -99,7 +99,7 @@ impl CMap {
     }
 
     fn map_bf_range_to_array(&mut self, low: u32, high: u32, array: Vec<u32>) -> Option<()> {
-        if high - low > MAX_MAP_RANGE {
+        if high.checked_sub(low)? > MAX_MAP_RANGE {
             return None;
         }
 

--- a/hayro-tests/pdfs/load/issue682.pdf
+++ b/hayro-tests/pdfs/load/issue682.pdf
@@ -1,0 +1,6 @@
+1
+1obj<</Pages 4 0R/Type/Catalog/Contents 7 0R/Resources <</Font<</3 10 0 R>>>>>>
+e7 0obj<< >>stream
+/3 1Tf
+10 0obj<<h/Subtype/Type3/ToUnicode 21 0R>>j21 0 obj<<>>stream
+beginbfrange<2><><endstream

--- a/hayro-tests/tests/load.rs
+++ b/hayro-tests/tests/load.rs
@@ -399,6 +399,12 @@ fn issue680() {
 }
 
 #[test]
+fn issue682() {
+    let file = include_bytes!("../pdfs/load/issue682.pdf");
+    load(file);
+}
+
+#[test]
 fn metadata_in_object_stream() {
     // Normally, in an encrypted PDF file strings need to be encrypted when they are not
     // in a stream. Therefore, we need to ensure that no encryption is applied when the object


### PR DESCRIPTION
Closes #682.