### PR TITLE
Change zune-jpeg version constraint to require 0.5.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pdf-writer = "0.14.0"
 sitro = { git = "https://github.com/LaurenzV/sitro", rev="fb804b3" }
 xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }
-zune-jpeg = { version = "<=0.5.4" }
+zune-jpeg = { version = "^0.5" }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "56820883", default-features = false, features = ["std", "png"] }
 fast_image_resize = { version = "5", default-features = false }
 fearless_simd = "0.3.0"


### PR DESCRIPTION
Hey! I ran into a build issue when using hayro alongside other crates that depend on zune-jpeg. The `<=0.5.4` constraint allows Cargo to pick 0.4.x versions, but the code uses 0.5.x APIs like `input_colorspace()` and `ColorSpace::MultiBand`. Changing to `^0.5` ensures we always get a compatible version.