### PR TITLE
Re-export PageExt and RectExt traits at crate root

### DIFF
--- a/hayro-interpret/src/lib.rs
+++ b/hayro-interpret/src/lib.rs
@@ -55,3 +55,4 @@ pub use hayro_syntax::Pdf;
 pub use interpret::*;
 pub use soft_mask::*;
 pub use types::*;
+pub use util::{PageExt, RectExt};


### PR DESCRIPTION
This re-exports `PageExt` and `RectExt` from the `util` module at the crate root, so users can import them as `hayro_interpret::PageExt` instead of `hayro_interpret::util::PageExt`. Makes it easier to use the `initial_transform` method on pages.