### PR TITLE
Add password support for encrypted PDFs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,9 @@ pdf-writer = "0.14.0"
 sitro = { git = "https://github.com/LaurenzV/sitro", rev="fb804b3" }
 xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }
-zune-jpeg = { version = "^0.5" }
+# zune_jpeg 0.5.6 has a bug where nearly all images decode incorrectly, so lock
+# to 0.5.5. until this is fixed.
+zune-jpeg = { version = "=0.5.5" }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "56820883", default-features = false, features = ["std", "png"] }
 fast_image_resize = { version = "5", default-features = false }
 fearless_simd = "0.3.0"

--- a/hayro-syntax/src/crypto/mod.rs
+++ b/hayro-syntax/src/crypto/mod.rs
@@ -28,8 +28,6 @@ const PASSWORD_PADDING: [u8; 32] = [
     0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80, 0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A,
 ];
 
-const PASSWORD: &[u8; 0] = b"";
-
 /// An error that occurred during decryption.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DecryptionError {
@@ -103,7 +101,11 @@ impl Decryptor {
     }
 }
 
-pub(crate) fn get(dict: &Dict<'_>, id: &[u8]) -> Result<Decryptor, DecryptionError> {
+pub(crate) fn get(
+    dict: &Dict<'_>,
+    id: &[u8],
+    password: &[u8],
+) -> Result<Decryptor, DecryptionError> {
     let filter = dict.get::<Name<'_>>(FILTER).ok_or(InvalidEncryption)?;
 
     if filter.deref() != b"Standard" {
@@ -153,6 +155,7 @@ pub(crate) fn get(dict: &Dict<'_>, id: &[u8]) -> Result<Decryptor, DecryptionErr
 
     let mut decryption_key = if revision <= 4 {
         let key = decryption_key_rev1234(
+            password,
             encrypt_metadata,
             revision,
             byte_length,
@@ -164,7 +167,7 @@ pub(crate) fn get(dict: &Dict<'_>, id: &[u8]) -> Result<Decryptor, DecryptionErr
 
         key
     } else {
-        decryption_key_rev56(dict, revision, &owner_string, &user_string)?
+        decryption_key_rev56(dict, revision, password, &owner_string, &user_string)?
     };
 
     // See pdf.js issue 19484.
@@ -439,6 +442,7 @@ fn compute_hash_rev56(
 
 /// Algorithm 2: Computing a file encryption key in order to encrypt a document (revision 4 and earlier)
 fn decryption_key_rev1234(
+    password: &[u8],
     encrypt_metadata: bool,
     revision: u8,
     byte_length: u16,
@@ -448,12 +452,17 @@ fn decryption_key_rev1234(
 ) -> Result<Vec<u8>, DecryptionError> {
     let mut md5_input = vec![];
 
-    // a) Convert password to PDFDocEncoding.
-    let password = PASSWORD_PADDING;
+    // a) Pad or truncate password to 32 bytes using PASSWORD_PADDING.
+    let mut padded_password = [0u8; 32];
+    let copy_len = password.len().min(32);
+    padded_password[..copy_len].copy_from_slice(&password[..copy_len]);
+    if copy_len < 32 {
+        padded_password[copy_len..].copy_from_slice(&PASSWORD_PADDING[..(32 - copy_len)]);
+    }
 
     // b) Initialise the MD5 hash function and pass the
     // result of step a) as input to this function.
-    md5_input.extend(&password);
+    md5_input.extend(&padded_password);
 
     // c) Pass the value of the encryption dictionary's O entry
     // to the MD5 hash function.
@@ -575,6 +584,7 @@ fn user_password_rev34(decryption_key: &[u8], id: &[u8]) -> Vec<u8> {
 fn decryption_key_rev56(
     dict: &Dict<'_>,
     revision: u8,
+    password: &[u8],
     owner_string: &object::String<'_>,
     user_string: &object::String<'_>,
 ) -> Result<Vec<u8>, DecryptionError> {
@@ -582,6 +592,7 @@ fn decryption_key_rev56(
     // the SASLprep (Internet RFC 4013) profile of stringprep (Internet RFC 3454) using the Normalize and BiDi
     // options, and then converting to a UTF-8 representation.
     // b) Truncate the UTF-8 representation to 127 bytes if it is longer than 127 bytes.
+    let password = &password[..password.len().min(127)];
 
     let string_len = if revision <= 4 { 32 } else { 48 };
 
@@ -602,7 +613,7 @@ fn decryption_key_rev56(
     // with an input string consisting of the UTF-8 password concatenated with the 8 bytes of
     // owner Validation Salt, concatenated with the 48-byte U string. If the 32-byte result
     // matches the first 32 bytes of the O string, this is the owner password.
-    if compute_hash_rev56(PASSWORD, owner_validation_salt, Some(trimmed_us), revision)?
+    if compute_hash_rev56(password, owner_validation_salt, Some(trimmed_us), revision)?
         == owner_hash
     {
         // d) Compute an intermediate owner key by computing a hash using algorithm 2.B with an input string
@@ -610,7 +621,7 @@ fn decryption_key_rev56(
         // concatenated with the 48-byte U string. The 32-byte result is the key used to decrypt the 32-byte OE string
         // using AES-256 in CBC mode with no padding and an initialization vector of zero. The 32-byte result is the file encryption key.
         let intermediate_owner_key =
-            compute_hash_rev56(PASSWORD, owner_key_salt, Some(trimmed_us), revision)?;
+            compute_hash_rev56(password, owner_key_salt, Some(trimmed_us), revision)?;
 
         let oe_string = dict
             .get::<object::String<'_>>(OE)
@@ -624,12 +635,12 @@ fn decryption_key_rev56(
         let zero_iv = [0_u8; 16];
 
         Ok(cipher.decrypt_cbc(&oe_string.get(), &zero_iv, false))
-    } else if compute_hash_rev56(PASSWORD, user_validation_salt, None, revision)? == user_hash {
+    } else if compute_hash_rev56(password, user_validation_salt, None, revision)? == user_hash {
         // e) Compute an intermediate user key by computing a hash using algorithm 2.B with an input string
         // consisting of the UTF-8 user password concatenated with the 8 bytes of user Key Salt. The 32-byte result
         // is the key used to decrypt the 32-byte UE string using AES-256 in CBC mode with no padding and an
         // initialization vector of zero. The 32-byte result is the file encryption key.
-        let intermediate_key = compute_hash_rev56(PASSWORD, user_key_salt, None, revision)?;
+        let intermediate_key = compute_hash_rev56(password, user_key_salt, None, revision)?;
 
         let ue_string = dict
             .get::<object::String<'_>>(UE)

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -34,7 +34,7 @@ pub(crate) enum XRefError {
 }
 
 /// Parse the "root" xref from the PDF.
-pub(crate) fn root_xref(data: PdfData) -> Result<XRef, XRefError> {
+pub(crate) fn root_xref(data: PdfData, password: &[u8]) -> Result<XRef, XRefError> {
     let mut xref_map = FxHashMap::default();
     let xref_pos = find_last_xref_pos(data.as_ref().as_ref()).ok_or(XRefError::Unknown)?;
     let trailer = populate_xref_impl(data.as_ref().as_ref(), xref_pos, &mut xref_map)
@@ -45,18 +45,19 @@ pub(crate) fn root_xref(data: PdfData) -> Result<XRef, XRefError> {
         xref_map,
         XRefInput::TrailerDictData(trailer),
         false,
+        password,
     )
 }
 
 /// Try to manually parse the PDF to build an xref table and trailer dictionary.
-pub(crate) fn fallback(data: PdfData) -> Option<XRef> {
+pub(crate) fn fallback(data: PdfData, password: &[u8]) -> Option<XRef> {
     warn!("xref table was invalid, trying to manually build xref table");
-    let (xref_map, xref_input) = fallback_xref_map(&data);
+    let (xref_map, xref_input) = fallback_xref_map(&data, password);
 
     if let Some(xref_input) = xref_input {
         warn!("rebuild xref table with {} entries", xref_map.len());
 
-        XRef::new(data.clone(), xref_map, xref_input, true).ok()
+        XRef::new(data.clone(), xref_map, xref_input, true, password).ok()
     } else {
         warn!("couldn't find trailer dictionary, failed to rebuild xref table");
 
@@ -64,14 +65,15 @@ pub(crate) fn fallback(data: PdfData) -> Option<XRef> {
     }
 }
 
-fn fallback_xref_map(data: &PdfData) -> (XrefMap, Option<XRefInput<'_>>) {
-    fallback_xref_map_inner(data, ReaderContext::dummy(), true)
+fn fallback_xref_map<'a>(data: &'a PdfData, password: &[u8]) -> (XrefMap, Option<XRefInput<'a>>) {
+    fallback_xref_map_inner(data, ReaderContext::dummy(), true, password)
 }
 
 fn fallback_xref_map_inner<'a>(
     data: &'a PdfData,
     mut dummy_ctx: ReaderContext<'a>,
     recurse: bool,
+    password: &[u8],
 ) -> (XrefMap, Option<XRefInput<'a>>) {
     let mut xref_map = FxHashMap::default();
     let mut trailer_dicts = vec![];
@@ -201,9 +203,10 @@ fn fallback_xref_map_inner<'a>(
             xref_map.clone(),
             XRefInput::TrailerDictData(trailer_dict.as_ref().map(|d| d.data()).unwrap()),
             true,
+            password,
         ) {
             let ctx = ReaderContext::new(&xref, false);
-            let (patched_map, _) = fallback_xref_map_inner(data, ctx, false);
+            let (patched_map, _) = fallback_xref_map_inner(data, ctx, false, password);
             xref_map = patched_map;
         }
     }
@@ -232,6 +235,7 @@ impl XRef {
         xref_map: XrefMap,
         input: XRefInput<'_>,
         repaired: bool,
+        password: &[u8],
     ) -> Result<Self, XRefError> {
         // This is a bit hacky, but the problem is we can't read the resolved trailer dictionary
         // before we actually created the xref struct. So we first create it using dummy data
@@ -260,7 +264,7 @@ impl XRef {
                         .read_with_context::<Dict<'_>>(&ReaderContext::new(&xref, false))
                         .ok_or(XRefError::Unknown)?;
 
-                    get_decryptor(&trailer_dict)?
+                    get_decryptor(&trailer_dict, password)?
                 }
                 XRefInput::RootRef(_) => Decryptor::None,
             }
@@ -436,7 +440,10 @@ impl XRef {
         let mut locked = r.map.try_write().unwrap();
         assert!(!locked.repaired);
 
-        let (xref_map, _) = fallback_xref_map(r.data.get());
+        // Note: repair() is called after the XRef was already successfully created,
+        // so we pass an empty password. Password-protected documents would have
+        // already been decrypted during initial loading.
+        let (xref_map, _) = fallback_xref_map(r.data.get(), b"");
         locked.xref_map = xref_map;
         locked.repaired = true;
     }
@@ -957,7 +964,7 @@ fn read_xref_table_trailer<'a>(
     reader.read_with_context::<Dict<'_>>(ctx)
 }
 
-fn get_decryptor(trailer_dict: &Dict<'_>) -> Result<Decryptor, XRefError> {
+fn get_decryptor(trailer_dict: &Dict<'_>, password: &[u8]) -> Result<Decryptor, XRefError> {
     if let Some(encryption_dict) = trailer_dict.get::<Dict<'_>>(ENCRYPT) {
         let id = if let Some(id) = trailer_dict
             .get::<Array<'_>>(ID)
@@ -969,7 +976,7 @@ fn get_decryptor(trailer_dict: &Dict<'_>) -> Result<Decryptor, XRefError> {
             vec![]
         };
 
-        get(&encryption_dict, &id).map_err(XRefError::Encryption)
+        get(&encryption_dict, &id, password).map_err(XRefError::Encryption)
     } else {
         Ok(Decryptor::None)
     }


### PR DESCRIPTION
## Summary
- Add `Pdf::new_with_password()` method to open password-protected PDFs
- Support both revision 1-4 (RC4/AES-128) and revision 5-6 (AES-256) encryption
- Maintain backwards compatibility: `Pdf::new()` delegates to `new_with_password()` with empty string

Closes #535

## Implementation
- Thread password parameter through `root_xref()`, `fallback()`, and `XRef::new()`
- Properly pad passwords to 32 bytes for rev 1-4 (using PASSWORD_PADDING)
- Truncate passwords to 127 bytes for rev 5-6