### PR TITLE
Lock zune-jpeg to version 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
  "rustc-hash",
  "sha2",
  "smallvec",
- "zune-jpeg 0.5.4",
+ "zune-jpeg 0.5.5",
 ]
 
 [[package]]
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc90edb93a24f57d041e871256001a0f6e20c2c56393495a0f96df8c0b33856"
+checksum = "dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e"
 dependencies = [
  "zune-core 0.5.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,9 @@ pdf-writer = "0.14.0"
 sitro = { git = "https://github.com/LaurenzV/sitro", rev="fb804b3" }
 xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }
-zune-jpeg = { version = "<=0.5.4" }
+# zune_jpeg 0.5.6 has a bug where nearly all images decode incorrectly, so lock
+# to 0.5.5. until this is fixed.
+zune-jpeg = { version = "=0.5.5" }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "56820883", default-features = false, features = ["std", "png"] }
 fast_image_resize = { version = "5", default-features = false }
 fearless_simd = "0.3.0"


### PR DESCRIPTION
Supersedes #690.