### PR TITLE
Re-export hayro-interpret

### DIFF
--- a/hayro/src/lib.rs
+++ b/hayro/src/lib.rs
@@ -34,6 +34,7 @@ This crate has one optional feature:
 #![deny(missing_docs)]
 
 use crate::renderer::Renderer;
+pub use hayro_interpret;
 use hayro_interpret::Device;
 use hayro_interpret::FillRule;
 pub use hayro_interpret::font::{


### PR DESCRIPTION
This adds a full re-export of `hayro-interpret`, allowing downstream users who need low-level interpreter APIs (e.g., implementing custom `Device` implementations) to access them via `hayro::hayro_interpret` without adding a separate `hayro-interpret` dependency.