### PR TITLE
Fix ToUnicode hex strings in bfrange arrays

### DIFF
--- a/hayro-interpret/src/font/cmap.rs
+++ b/hayro-interpret/src/font/cmap.rs
@@ -714,6 +714,21 @@ endbfrange"#
     }
 
     #[test]
+    fn test_parse_beginbfrange_with_high_byte_hex_array() {
+        // Test hex strings with bytes >= 0x80
+        // This verifies that chars().count() is needed (not as_bytes().len())
+        // because bytes >= 0x80 become multi-byte UTF-8 sequences
+        let input = r#"1 beginbfrange
+<00B3> <00B3> [<00E9>]
+endbfrange"#
+            .to_string();
+
+        let cmap = parse_cmap(&input).unwrap();
+
+        assert_eq!(cmap.lookup_code(0xB3), Some(0x00E9)); // é (U+00E9)
+    }
+
+    #[test]
     fn test_parse_begincidchar() {
         let input = r#"1 begincidchar
 <14> 0


### PR DESCRIPTION
Fixes parsing of hex string Unicode values in `beginbfrange` array format.

Previously, hex strings like `[<2014>]` in ToUnicode CMaps were parsed incorrectly. Only the first byte was used, causing `as_unicode()` to return wrong values (e.g., space instead of em-dash).

Adds a test case for this scenario.