### PR TITLE
Make fields of `ObjectIdentifier` public

### DIFF
--- a/hayro-syntax/src/crypto/mod.rs
+++ b/hayro-syntax/src/crypto/mod.rs
@@ -249,8 +249,8 @@ fn decrypt_rc_aes(
     // n-byte file encryption key to n + 5 bytes by appending the low-order 3 bytes of
     // the object number and the low-order 2 bytes of the generation number in that
     // order, low-order byte first.
-    key.extend(&id.obj_num.to_le_bytes()[..3]);
-    key.extend(&id.gen_num.to_le_bytes()[..2]);
+    key.extend(&id.obj_number.to_le_bytes()[..3]);
+    key.extend(&id.gen_number.to_le_bytes()[..2]);
 
     // If using the AES algorithm, extend the file encryption key an additional 4 bytes by adding the value
     // "sAlT", which corresponds to the hexadecimal values 0x73, 0x41, 0x6C, 0x54. (This addition is done

--- a/hayro-syntax/src/object/mod.rs
+++ b/hayro-syntax/src/object/mod.rs
@@ -213,26 +213,34 @@ impl<'a, T: Readable<'a>> FromBytes<'a> for T {
 /// An identifier for a PDF object.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct ObjectIdentifier {
-    pub(crate) obj_num: i32,
-    pub(crate) gen_num: i32,
+    /// The object number.
+    pub obj_number: i32,
+    /// The generation number.
+    pub gen_number: i32,
 }
 
 impl ObjectIdentifier {
     /// Create a new `ObjectIdentifier`.
-    pub fn new(obj_num: i32, gen_num: i32) -> Self {
-        Self { obj_num, gen_num }
+    pub fn new(obj_number: i32, gen_number: i32) -> Self {
+        Self {
+            obj_number,
+            gen_number,
+        }
     }
 }
 
 impl Readable<'_> for ObjectIdentifier {
     fn read(r: &mut Reader<'_>, _: &ReaderContext<'_>) -> Option<Self> {
-        let obj_num = r.read_without_context::<i32>()?;
+        let obj_number = r.read_without_context::<i32>()?;
         r.skip_white_spaces_and_comments();
-        let gen_num = r.read_without_context::<i32>()?;
+        let gen_number = r.read_without_context::<i32>()?;
         r.skip_white_spaces_and_comments();
         r.forward_tag(b"obj")?;
 
-        Some(Self { obj_num, gen_num })
+        Some(Self {
+            obj_number,
+            gen_number,
+        })
     }
 }
 

--- a/hayro-syntax/src/object/ref.rs
+++ b/hayro-syntax/src/object/ref.rs
@@ -31,6 +31,12 @@ impl From<ObjRef> for ObjectIdentifier {
     }
 }
 
+impl From<ObjectIdentifier> for ObjRef {
+    fn from(value: ObjectIdentifier) -> Self {
+        Self::new(value.obj_number, value.gen_number)
+    }
+}
+
 impl Skippable for ObjRef {
     fn skip(r: &mut Reader<'_>, _: bool) -> Option<()> {
         r.skip_not_in_content_stream::<i32>()?;

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -128,7 +128,7 @@ fn fallback_xref_map_inner<'a>(
                     {
                         xref_map.insert(
                             id,
-                            EntryType::ObjStream(last_obj_num.obj_num as u32, idx as u32),
+                            EntryType::ObjStream(last_obj_num.obj_number as u32, idx as u32),
                         );
                     }
                 }


### PR DESCRIPTION
Also rename both fields to match the naming in `ObjRef`, and implement a conversion both ways.

I’m not sure why the fields were initially private, so it’s possible I’m missing something. My use case is that I want to get the `ObjectIdentifier` of an object I read out from a PDF in order to serialize it.

(Also, at least according to the PDF specification, the object number is positive and the generation number non-negative. Out of curiosity, is there a particular reason `i32` was chosen over `u32`?)