### PR TITLE
hayro-jpeg2000: Drop manual `total_bytes` implementation

### DIFF
--- a/hayro-jpeg2000/src/image.rs
+++ b/hayro-jpeg2000/src/image.rs
@@ -43,19 +43,6 @@ impl ImageDecoder for Image<'_> {
             "failed to decode image",
         )))
     }
-
-    fn total_bytes(&self) -> u64 {
-        let base = self.width() as u64 * self.height() as u64;
-        let factor = match self.color_type() {
-            ColorType::L8 => 1,
-            ColorType::La8 => 2,
-            ColorType::Rgb8 => 3,
-            ColorType::Rgba8 => 4,
-            _ => unreachable!(),
-        };
-
-        base * factor as u64
-    }
 }
 
 fn convert_inner(image: &Image<'_>, buf: &mut [u8]) -> Option<()> {


### PR DESCRIPTION
`image` already provides a default implementation of this function that handles overflows better by using saturating arithmetic: https://docs.rs/image/0.25.9/src/image/io/decoder.rs.html#66-71

So there is no need to manually implement it and to reintroduce potential integer overflows.