### PR TITLE
Avoid a large memmove of all zeroes when creating a `SimdBuffer` via `SimdBuffer::zeros()`

### DIFF
--- a/hayro-jpeg2000/src/math.rs
+++ b/hayro-jpeg2000/src/math.rs
@@ -540,8 +540,10 @@ impl<const N: usize> SimdBuffer<N> {
     }
 
     /// Create a new `SimdBuffer` filled with zeros.
-    pub(crate) fn zeros(len: usize) -> Self {
-        Self::new(vec![0.0; len])
+    pub(crate) fn zeros(original_len: usize) -> Self {
+        let padded_len = Self::padded_len(original_len);
+        let data = vec![0.0; padded_len];
+        Self { data, original_len }
     }
 
     /// Returns only the original (non-padded) data as an immutable slice.


### PR DESCRIPTION
Right now when calling `SimdBuffer::zeros`, it first creates a `Vec` and zero-initializes it, then passes it to `SimdBuffer::new()`, which needs to grow the capacity of the Vec, so it allocates a new slightly larger chunk of memory and copies all those zeroes there in a separate step.

You can see this clearly on the profile: https://share.firefox.dev/3YMOA6C

This PR avoids that two-step process and creates a `Vec` of the correct size directly. This speeds up end-to-end decoding of a JPEG2000 image I had lying around by 3.5%.