### PR TITLE
Add a fast path for zero-initializing a scratch buffer

### DIFF
--- a/hayro-jpeg2000/src/j2c/build.rs
+++ b/hayro-jpeg2000/src/j2c/build.rs
@@ -5,9 +5,9 @@ use super::rect::IntRect;
 use super::tag_tree::TagTree;
 use super::tile::{ResolutionTile, Tile};
 use crate::error::{DecodingError, Result};
+use alloc::vec;
 use core::iter;
 use core::ops::Range;
-use alloc::vec;
 
 /// Build and allocate all necessary structures to process the code-blocks
 /// for a specific tile. Also parses the segments for each code-block.


### PR DESCRIPTION
vec![0.0; len]; will request pre-zeroed memory from the OS if possible, so we don't have to memset it ourselves. Improves end-to-end decoding time by up to 2.8% when the memory allocator supports this.