### PR TITLE
hayro-interpret: Update soft mask when restoring state

### DIFF
--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -175,6 +175,12 @@ impl<'a> Context<'a> {
         if self.states.len() > 1 {
             self.states.pop();
         }
+
+        device.set_soft_mask(
+            self.states
+                .last()
+                .and_then(|l| l.graphics_state.soft_mask.clone()),
+        );
     }
 
     pub(crate) fn path(&self) -> &BezPath {


### PR DESCRIPTION
When a Device implementation uses `set_soft_mask` to track active soft masks with push/pop semantics, calling `pop_clip_path` while a mask is active can result in the wrong item being popped.

In PDF, the `Q` operator restores the entire graphics state including the soft mask. However, hayro's `restore_state` only calls `pop_clip_path`, leaving Device implementations unaware that the mask should also be cleared.

## Possible Fix

Call `device.set_soft_mask(None)` before popping clip paths in `restore_state`. This ensures Device implementations see the mask cleared before clip paths are popped, maintaining the correct push/pop order.

## Example

A PDF with:
```
q          → push_clip_path()
gs /SMask  → set_soft_mask(Some(mask))
sh         → draw_path()
Q          → restore_state() → pop_clip_path()
```

Without this fix, if a Device pushes something for `set_soft_mask`, `pop_clip_path` would pop the mask instead of the clip path.

Here's a PDF with this sort of pattern:
[baden_1_snipped.pdf](https://github.com/user-attachments/files/24824676/baden_1_snipped.pdf)
