### PR TITLE
hayro-font: Fix CFF charset parsing for fonts with oversized final range

### DIFF
--- a/hayro-font/src/cff/charset.rs
+++ b/hayro-font/src/cff/charset.rs
@@ -214,6 +214,8 @@ pub(crate) fn parse_charset<'a>(
                 while total_left > 0 {
                     s.skip::<StringId>(); // first
                     let left = s.read::<u8>()?;
+                    // Use saturating sub to be more lenient against invalid
+                    // files, see #892.
                     total_left = total_left.saturating_sub(u16::from(left) + 1);
                     count += 1;
                 }
@@ -230,6 +232,8 @@ pub(crate) fn parse_charset<'a>(
                 while total_left > 0 {
                     s.skip::<StringId>(); // first
                     let left = s.read::<u16>()?.checked_add(1)?;
+                    // Use saturating sub to be more lenient against invalid
+                    // files, see #892.
                     total_left = total_left.saturating_sub(left);
                     count += 1;
                 }

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -1149,5 +1149,9 @@
     "id": "password_2",
     "file": "pdfs/custom/password_2.pdf",
     "password": "samplefiles"
+  },
+  {
+    "id": "issue892",
+    "link": true
   }
 ]

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -280,6 +280,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn password_encrypted_rc4_128() { run_render_test_with_password("password_encrypted_rc4_128", "pdfs/custom/password_encrypted_rc4_128.pdf", None, "testpw"); }
 #[test] fn password_1() { run_render_test_with_password("password_1", "pdfs/custom/password_1.pdf", None, "supersecret"); }
 #[test] fn password_2() { run_render_test_with_password("password_2", "pdfs/custom/password_2.pdf", None, "samplefiles"); }
+#[test] fn issue892() { run_render_test("issue892", "downloads/custom/issue892.pdf", None); }
 #[test] fn pdfjs_20130226130259() { run_render_test("pdfjs_20130226130259", "downloads/pdfjs/20130226130259.pdf", Some("0..=0")); }
 #[test] fn pdfjs_ContentStreamNoCycleType3insideType3() { run_render_test("pdfjs_ContentStreamNoCycleType3insideType3", "downloads/pdfjs/ContentStreamNoCycleType3insideType3.pdf", None); }
 #[test] fn pdfjs_High_Pressure_Measurement_WP_001287() { run_render_test("pdfjs_High_Pressure_Measurement_WP_001287", "downloads/pdfjs/High-Pressure-Measurement-WP-001287.pdf", Some("2..=2")); }


### PR DESCRIPTION
Some CFF fonts have a final charset range that slightly exceeds the declared glyph count. The current parser uses `checked_sub` which returns `None` on underflow, causing the font to fail parsing entirely and making all text using that font invisible.

For example, a font declares 578 glyphs but its charset ranges sum to 579. When parsing:
- `total_left = 577` (578 - 1, since .notdef is omitted)
- Final range has `left + 1 = 578`
- `577.checked_sub(578)` returns `None` → font fails to parse

Using `saturating_sub` instead allows the loop to exit normally when ranges exceed the remaining count. I believe this should be safe since we're only counting ranges to determine array size - the actual glyph data is still bounded by `number_of_glyphs`. Other renderers (pdfium, mupdf, poppler) handle these fonts without issue.

Here's a test PDF that reproduces the issue (can share more if necessary):
[cff-charset-testcase.pdf](https://github.com/user-attachments/files/24840977/cff-charset-testcase.pdf)