### PR TITLE
hayro-syntax: Allow pages without `Contents` field

### DIFF
--- a/hayro-syntax/src/page.rs
+++ b/hayro-syntax/src/page.rs
@@ -74,6 +74,7 @@ impl<'a> Pages<'a> {
                     &dict,
                     &PagesContext::new(),
                     Resources::new(Dict::empty(), None, ctx),
+                    true,
                 )
             {
                 pages.push(page);
@@ -134,7 +135,7 @@ fn resolve_pages<'a>(
             // Let's be lenient and assume it's a `Page` in case it's `None` or something else
             // (see corpus test case 0083781).
             _ => {
-                if let Some(page) = Page::new(&dict, &ctx, resources.clone()) {
+                if let Some(page) = Page::new(&dict, &ctx, resources.clone(), false) {
                     entries.push(page);
                 }
             }
@@ -169,7 +170,18 @@ pub struct Page<'a> {
 }
 
 impl<'a> Page<'a> {
-    fn new(dict: &Dict<'a>, ctx: &PagesContext, resources: Resources<'a>) -> Option<Self> {
+    fn new(
+        dict: &Dict<'a>,
+        ctx: &PagesContext,
+        resources: Resources<'a>,
+        brute_force: bool,
+    ) -> Option<Self> {
+        // In general, pages without content are allowed, but in case we are brute-forcing
+        // we ignore them.
+        if brute_force && !dict.contains_key(CONTENTS) {
+            return None;
+        }
+
         let media_box = dict.get::<Rect>(MEDIA_BOX).or(ctx.media_box).unwrap_or(A4);
 
         let crop_box = dict

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -1153,5 +1153,9 @@
   {
     "id": "issue892",
     "link": true
+  },
+  {
+    "id": "blank_page_without_contents",
+    "file": "pdfs/custom/blank_page_without_contents.pdf"
   }
 ]

--- a/hayro-tests/pdfs/custom/blank_page_without_contents.pdf
+++ b/hayro-tests/pdfs/custom/blank_page_without_contents.pdf
@@ -1,0 +1,144 @@
+%PDF-1.4
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 3
+  /Kids [
+    3 0 R
+    4 0 R
+    5 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 6 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+%% Original object ID: 5 0
+5 0 obj
+<<
+  /Contents 9 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 8 0 R
+    >>
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /Length 7 0 R
+>>
+stream
+BT /F1 24 Tf 100 700 Td (Page 1) Tj ET
+endstream
+endobj
+
+7 0 obj
+39
+endobj
+
+%% Original object ID: 9 0
+8 0 obj
+<<
+  /BaseFont /Helvetica
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Contents for page 3
+%% Original object ID: 7 0
+9 0 obj
+<<
+  /Length 10 0 R
+>>
+stream
+BT /F1 24 Tf 100 700 Td (Page 3) Tj ET
+endstream
+endobj
+
+10 0 obj
+39
+endobj
+
+xref
+0 11
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000262 00000 n 
+0000000472 00000 n 
+0000000628 00000 n 
+0000000851 00000 n 
+0000000945 00000 n 
+0000000991 00000 n 
+0000001118 00000 n 
+0000001213 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 11
+  /ID [<5e5c04498822bac433b201a170586ce2><5e5c04498822bac433b201a170586ce2>]
+>>
+startxref
+1233
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -281,6 +281,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn password_1() { run_render_test_with_password("password_1", "pdfs/custom/password_1.pdf", None, "supersecret"); }
 #[test] fn password_2() { run_render_test_with_password("password_2", "pdfs/custom/password_2.pdf", None, "samplefiles"); }
 #[test] fn issue892() { run_render_test("issue892", "downloads/custom/issue892.pdf", None); }
+#[test] fn blank_page_without_contents() { run_render_test("blank_page_without_contents", "pdfs/custom/blank_page_without_contents.pdf", None); }
 #[test] fn pdfjs_20130226130259() { run_render_test("pdfjs_20130226130259", "downloads/pdfjs/20130226130259.pdf", Some("0..=0")); }
 #[test] fn pdfjs_ContentStreamNoCycleType3insideType3() { run_render_test("pdfjs_ContentStreamNoCycleType3insideType3", "downloads/pdfjs/ContentStreamNoCycleType3insideType3.pdf", None); }
 #[test] fn pdfjs_High_Pressure_Measurement_WP_001287() { run_render_test("pdfjs_High_Pressure_Measurement_WP_001287", "downloads/pdfjs/High-Pressure-Measurement-WP-001287.pdf", Some("2..=2")); }


### PR DESCRIPTION
Pages without a `/Contents` entry are valid blank pages in PDF, but `Page::new()` was rejecting them with an early return. This caused PDFs with intentional blank pages to be parsed with fewer pages than expected.

For example, an 8-page PDF with one blank page (page 5 has no `/Contents` key) would only return 7 pages from `pdf.pages()`.

The fix removes this check. `page_stream()` already handles missing content gracefully by returning `None`.