### PR TITLE
hayro-interpret: Forward marked content operators to Device

### DIFF
--- a/hayro-interpret/src/device.rs
+++ b/hayro-interpret/src/device.rs
@@ -44,4 +44,11 @@ pub trait Device<'a> {
     fn pop_clip_path(&mut self);
     /// Pop the last transparency group from the blend stack.
     fn pop_transparency_group(&mut self);
+    /// Called at the beginning of a marked content sequence (BMC/BDC).
+    ///
+    /// The tag is the marked content tag (e.g. b"P", b"Span"). The mcid is
+    /// the marked content identifier from the properties dict, if present.
+    fn begin_marked_content(&mut self, _tag: &[u8], _mcid: Option<i32>) {}
+    /// Called at the end of a marked content sequence (EMC).
+    fn end_marked_content(&mut self) {}
 }


### PR DESCRIPTION
The `BMC`, `BDC`, and `EMC` operators are currently handled only for optional content group (OCG) tracking. This adds `begin_marked_content` and `end_marked_content` callbacks to the `Device` trait so implementations can track marked content sequences.

Both methods have default empty implementations so existing Device implementations are unaffected.

For `BDC` (BeginMarkedContentWithProperties), the MCID is extracted from the properties dict and passed to the device. `BMC` passes `None` for the MCID. The tag name is passed in both cases.

This is useful for building structure tree extractors that need to map marked content IDs back to the drawing operations they contain.