### PR TITLE
Fix resource exhaustion

### DIFF
--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -14,7 +14,7 @@ use hayro_syntax::xref::XRef;
 use kurbo::{Affine, BezPath, PathEl, Point, Rect, Shape};
 use std::collections::HashMap;
 
-/// Maximum recursion depth for form XObjects to prevent stack overflow
+/// Maximum recursion depth for form `XObject`s to prevent stack overflow
 /// from circular references.
 const MAX_FORM_XOBJECT_DEPTH: u32 = 100;
 
@@ -256,19 +256,22 @@ impl<'a> Context<'a> {
         self.states.len()
     }
 
-    /// Try to enter a form XObject. Returns `false` if the recursion depth
+    /// Try to enter a form `XObject`. Returns `false` if the recursion depth
     /// limit has been reached (to prevent stack overflow from circular
-    /// form XObject references).
+    /// form `XObject` references).
     pub(crate) fn enter_form_xobject(&mut self) -> bool {
         if self.form_xobject_depth >= MAX_FORM_XOBJECT_DEPTH {
-            warn!("form XObject recursion depth limit ({}) exceeded", MAX_FORM_XOBJECT_DEPTH);
+            warn!(
+                "form XObject recursion depth limit ({}) exceeded",
+                MAX_FORM_XOBJECT_DEPTH
+            );
             return false;
         }
         self.form_xobject_depth += 1;
         true
     }
 
-    /// Exit a form XObject, decrementing the recursion depth counter.
+    /// Exit a form `XObject`, decrementing the recursion depth counter.
     pub(crate) fn exit_form_xobject(&mut self) {
         self.form_xobject_depth = self.form_xobject_depth.saturating_sub(1);
     }

--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -14,6 +14,10 @@ use hayro_syntax::xref::XRef;
 use kurbo::{Affine, BezPath, PathEl, Point, Rect, Shape};
 use std::collections::HashMap;
 
+/// Maximum recursion depth for form XObjects to prevent stack overflow
+/// from circular references.
+const MAX_FORM_XOBJECT_DEPTH: u32 = 100;
+
 /// A context for interpreting PDF files.
 pub struct Context<'a> {
     states: Vec<State<'a>>,
@@ -28,6 +32,7 @@ pub struct Context<'a> {
     pub(crate) object_cache: Cache,
     pub(crate) xref: &'a XRef,
     pub(crate) ocg_state: OcgState,
+    form_xobject_depth: u32,
 }
 
 impl<'a> Context<'a> {
@@ -72,6 +77,7 @@ impl<'a> Context<'a> {
             font_cache: HashMap::new(),
             object_cache: cache,
             ocg_state,
+            form_xobject_depth: 0,
         }
     }
 
@@ -248,6 +254,23 @@ impl<'a> Context<'a> {
 
     pub(crate) fn num_states(&self) -> usize {
         self.states.len()
+    }
+
+    /// Try to enter a form XObject. Returns `false` if the recursion depth
+    /// limit has been reached (to prevent stack overflow from circular
+    /// form XObject references).
+    pub(crate) fn enter_form_xobject(&mut self) -> bool {
+        if self.form_xobject_depth >= MAX_FORM_XOBJECT_DEPTH {
+            warn!("form XObject recursion depth limit ({}) exceeded", MAX_FORM_XOBJECT_DEPTH);
+            return false;
+        }
+        self.form_xobject_depth += 1;
+        true
+    }
+
+    /// Exit a form XObject, decrementing the recursion depth counter.
+    pub(crate) fn exit_form_xobject(&mut self) {
+        self.form_xobject_depth = self.form_xobject_depth.saturating_sub(1);
     }
 
     pub(crate) fn resolve_font(&mut self, font_dict: &Dict<'a>) -> Option<TextStateFont<'a>> {

--- a/hayro-interpret/src/x_object.rs
+++ b/hayro-interpret/src/x_object.rs
@@ -324,6 +324,28 @@ impl<'a> ImageXObject<'a> {
             return None;
         }
 
+        // Reject absurdly large images that would cause excessive memory allocation.
+        // 65535 per side matches the maximum dimension in most image formats, and
+        // 500 million total pixels prevents multi-GB allocations from decoded image data.
+        const MAX_IMAGE_DIMENSION: u32 = 65535;
+        const MAX_TOTAL_PIXELS: u64 = 500_000_000;
+
+        if width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION {
+            warn!(
+                "image dimensions {}x{} exceed maximum of {}",
+                width, height, MAX_IMAGE_DIMENSION
+            );
+            return None;
+        }
+
+        if (width as u64) * (height as u64) > MAX_TOTAL_PIXELS {
+            warn!(
+                "image pixel count {} exceeds maximum of {}",
+                (width as u64) * (height as u64), MAX_TOTAL_PIXELS
+            );
+            return None;
+        }
+
         Some(Self {
             width,
             cache: cache.clone(),

--- a/hayro-interpret/src/x_object.rs
+++ b/hayro-interpret/src/x_object.rs
@@ -341,7 +341,8 @@ impl<'a> ImageXObject<'a> {
         if (width as u64) * (height as u64) > MAX_TOTAL_PIXELS {
             warn!(
                 "image pixel count {} exceeds maximum of {}",
-                (width as u64) * (height as u64), MAX_TOTAL_PIXELS
+                (width as u64) * (height as u64),
+                MAX_TOTAL_PIXELS
             );
             return None;
         }

--- a/hayro-interpret/src/x_object.rs
+++ b/hayro-interpret/src/x_object.rs
@@ -110,11 +110,16 @@ pub(crate) fn draw_form_xobject<'a, 'b>(
         return;
     }
 
+    if !context.enter_form_xobject() {
+        return;
+    }
+
     let has_oc = xobject_oc(&x_object.dict, context);
     if !context.ocg_state.is_visible() {
         if has_oc {
             context.ocg_state.end_marked_content();
         }
+        context.exit_form_xobject();
         return;
     }
 
@@ -170,6 +175,8 @@ pub(crate) fn draw_form_xobject<'a, 'b>(
     if has_oc {
         context.ocg_state.end_marked_content();
     }
+
+    context.exit_form_xobject();
 }
 
 pub(crate) fn draw_image_xobject<'a, 'b>(

--- a/hayro-syntax/src/filter/lzw_flate.rs
+++ b/hayro-syntax/src/filter/lzw_flate.rs
@@ -20,7 +20,7 @@ pub(crate) mod flate {
         fn read_limited(mut reader: impl Read) -> Option<Vec<u8>> {
             let limit = MAX_DECOMPRESSED_SIZE;
             let mut result = Vec::new();
-            let mut buf = [0u8; 8192];
+            let mut buf = [0_u8; 8192];
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => return Some(result),

--- a/hayro-syntax/src/filter/lzw_flate.rs
+++ b/hayro-syntax/src/filter/lzw_flate.rs
@@ -18,6 +18,7 @@ pub(crate) mod flate {
         use std::io::Read;
 
         fn read_limited(mut reader: impl Read) -> Option<Vec<u8>> {
+            let limit = MAX_DECOMPRESSED_SIZE;
             let mut result = Vec::new();
             let mut buf = [0u8; 8192];
             loop {
@@ -25,7 +26,7 @@ pub(crate) mod flate {
                     Ok(0) => return Some(result),
                     Ok(n) => {
                         result.extend_from_slice(&buf[..n]);
-                        if result.len() > super::MAX_DECOMPRESSED_SIZE {
+                        if result.len() > limit {
                             warn!("decompressed stream exceeds maximum size limit");
                             return None;
                         }

--- a/hayro-syntax/src/filter/lzw_flate.rs
+++ b/hayro-syntax/src/filter/lzw_flate.rs
@@ -4,6 +4,9 @@ use crate::object::dict::keys::{BITS_PER_COMPONENT, COLORS, COLUMNS, EARLY_CHANG
 use alloc::vec;
 use alloc::vec::Vec;
 
+/// Maximum decompressed output size (256 MB) to prevent decompression bombs.
+pub(crate) const MAX_DECOMPRESSED_SIZE: usize = 256 * 1024 * 1024;
+
 pub(crate) mod flate {
     use super::*;
     use crate::filter::lzw_flate::{PredictorParams, apply_predictor};
@@ -14,16 +17,30 @@ pub(crate) mod flate {
         use flate2::read::{DeflateDecoder, ZlibDecoder};
         use std::io::Read;
 
-        fn zlib_stream(data: &[u8]) -> Option<Vec<u8>> {
-            let mut decoder = ZlibDecoder::new(data);
+        fn read_limited(mut reader: impl Read) -> Option<Vec<u8>> {
             let mut result = Vec::new();
-            decoder.read_to_end(&mut result).ok().map(|_| result)
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => return Some(result),
+                    Ok(n) => {
+                        result.extend_from_slice(&buf[..n]);
+                        if result.len() > super::MAX_DECOMPRESSED_SIZE {
+                            warn!("decompressed stream exceeds maximum size limit");
+                            return None;
+                        }
+                    }
+                    Err(_) => return None,
+                }
+            }
+        }
+
+        fn zlib_stream(data: &[u8]) -> Option<Vec<u8>> {
+            read_limited(ZlibDecoder::new(data))
         }
 
         fn deflate_stream(data: &[u8]) -> Option<Vec<u8>> {
-            let mut decoder = DeflateDecoder::new(data);
-            let mut result = Vec::new();
-            decoder.read_to_end(&mut result).ok().map(|_| result)
+            read_limited(DeflateDecoder::new(data))
         }
 
         let decoded = zlib_stream(data)
@@ -96,6 +113,10 @@ pub(crate) mod flate {
             fn decode(&mut self) -> Option<Vec<u8>> {
                 while !self.eof && self.pos < self.data.len() {
                     self.read_block();
+                    if self.output.len() > super::super::MAX_DECOMPRESSED_SIZE {
+                        warn!("decompressed stream exceeds maximum size limit");
+                        return None;
+                    }
                 }
 
                 Some(core::mem::take(&mut self.output))
@@ -631,6 +652,11 @@ pub(crate) mod lzw {
                         return None;
                     }
 
+                    if decoded.len() > super::MAX_DECOMPRESSED_SIZE {
+                        warn!("decompressed LZW stream exceeds maximum size limit");
+                        return None;
+                    }
+
                     bit_size = table.code_length();
                     prev = Some(new);
                 }
@@ -1069,5 +1095,29 @@ mod tests {
                 4, 3, 1, 252, 5, 253, 6, 1, 229, 254,
             ],
         );
+    }
+
+    #[test]
+    fn decompression_limit_constant_is_reasonable() {
+        use super::MAX_DECOMPRESSED_SIZE;
+        // 256 MB
+        assert_eq!(MAX_DECOMPRESSED_SIZE, 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn valid_flate_within_limit_succeeds() {
+        // A valid zlib-compressed "Hello" should decompress fine.
+        let input = [
+            0x78, 0x9c, 0xf3, 0x48, 0xcd, 0xc9, 0xc9, 0x7, 0x0, 0x5, 0x8c, 0x1, 0xf5,
+        ];
+        let decoded = flate::decode(&input, &Dict::default()).unwrap();
+        assert_eq!(decoded, b"Hello");
+    }
+
+    #[test]
+    fn valid_lzw_within_limit_succeeds() {
+        let input = [0x80, 0x0B, 0x60, 0x50, 0x22, 0x0C, 0x0C, 0x85, 0x01];
+        let decoded = lzw::decode(&input, &Dict::default()).unwrap();
+        assert_eq!(decoded, vec![45, 45, 45, 45, 45, 65, 45, 45, 45, 66]);
     }
 }

--- a/hayro-syntax/src/filter/run_length.rs
+++ b/hayro-syntax/src/filter/run_length.rs
@@ -2,6 +2,8 @@ use crate::reader::Reader;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use super::lzw_flate::MAX_DECOMPRESSED_SIZE;
+
 pub(crate) fn decode(data: &[u8]) -> Option<Vec<u8>> {
     let mut reader = Reader::new(data);
     let mut decoded = vec![];
@@ -23,6 +25,11 @@ pub(crate) fn decode(data: &[u8]) -> Option<Vec<u8>> {
                 let length = 257 - length as usize;
                 decoded.extend([reader.read_byte()?].repeat(length));
             }
+        }
+
+        if decoded.len() > MAX_DECOMPRESSED_SIZE {
+            warn!("decompressed RunLength stream exceeds maximum size limit");
+            return None;
         }
     }
 

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -760,7 +760,10 @@ fn populate_xref_impl_inner<'a>(
     }
 
     if visited.len() > MAX_XREF_CHAIN_DEPTH {
-        warn!("xref PREV chain exceeds maximum depth of {}", MAX_XREF_CHAIN_DEPTH);
+        warn!(
+            "xref PREV chain exceeds maximum depth of {}",
+            MAX_XREF_CHAIN_DEPTH
+        );
         return None;
     }
 

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -21,6 +21,7 @@ use crate::reader::{Readable, ReaderContext, ReaderExt};
 use crate::sync::{Arc, FxHashMap, RwLock, RwLockExt};
 use crate::trivia::is_regular_character;
 use crate::{PdfData, object};
+use alloc::collections::BTreeSet;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::max;
@@ -740,6 +741,29 @@ impl XRefEntry {
 }
 
 fn populate_xref_impl<'a>(data: &'a [u8], pos: usize, xref_map: &mut XrefMap) -> Option<&'a [u8]> {
+    let mut visited = BTreeSet::new();
+    populate_xref_impl_inner(data, pos, xref_map, &mut visited)
+}
+
+/// Maximum depth of PREV chain traversal as defense-in-depth.
+const MAX_XREF_CHAIN_DEPTH: usize = 1024;
+
+fn populate_xref_impl_inner<'a>(
+    data: &'a [u8],
+    pos: usize,
+    xref_map: &mut XrefMap,
+    visited: &mut BTreeSet<usize>,
+) -> Option<&'a [u8]> {
+    if !visited.insert(pos) {
+        warn!("circular xref PREV chain detected at offset {}", pos);
+        return None;
+    }
+
+    if visited.len() > MAX_XREF_CHAIN_DEPTH {
+        warn!("xref PREV chain exceeds maximum depth of {}", MAX_XREF_CHAIN_DEPTH);
+        return None;
+    }
+
     let mut reader = Reader::new(data);
     reader.jump(pos);
     // In case the position points to before the object number of a xref stream.
@@ -751,9 +775,9 @@ fn populate_xref_impl<'a>(data: &'a [u8], pos: usize, xref_map: &mut XrefMap) ->
         .read_without_context::<ObjectIdentifier>()
         .is_some()
     {
-        populate_from_xref_stream(data, &mut r2, xref_map)
+        populate_from_xref_stream(data, &mut r2, xref_map, visited)
     } else {
-        populate_from_xref_table(data, &mut r2, xref_map)
+        populate_from_xref_table(data, &mut r2, xref_map, visited)
     }
 }
 
@@ -779,6 +803,7 @@ fn populate_from_xref_table<'a>(
     data: &'a [u8],
     reader: &mut Reader<'a>,
     insert_map: &mut XrefMap,
+    visited: &mut BTreeSet<usize>,
 ) -> Option<&'a [u8]> {
     let trailer = {
         let mut reader = reader.clone();
@@ -793,13 +818,13 @@ fn populate_from_xref_table<'a>(
 
     if let Some(prev) = trailer.get::<i32>(PREV) {
         // First insert the entries from any previous xref tables.
-        populate_xref_impl(data, prev as usize, insert_map)?;
+        populate_xref_impl_inner(data, prev as usize, insert_map, visited)?;
     }
 
     // In hybrid files, entries in `XRefStm` should have higher priority, therefore we insert them
     // after looking at `PREV`.
     if let Some(xref_stm) = trailer.get::<i32>(XREF_STM) {
-        populate_xref_impl(data, xref_stm as usize, insert_map)?;
+        populate_xref_impl_inner(data, xref_stm as usize, insert_map, visited)?;
     }
 
     while let Some(header) = reader.read_without_context::<SubsectionHeader>() {
@@ -831,6 +856,7 @@ fn populate_from_xref_stream<'a>(
     data: &'a [u8],
     reader: &mut Reader<'a>,
     insert_map: &mut XrefMap,
+    visited: &mut BTreeSet<usize>,
 ) -> Option<&'a [u8]> {
     let stream = reader
         .read_with_context::<IndirectObject<Stream<'_>>>(&ReaderContext::dummy())?
@@ -838,7 +864,7 @@ fn populate_from_xref_stream<'a>(
 
     if let Some(prev) = stream.dict().get::<i32>(PREV) {
         // First insert the entries from any previous xref tables.
-        let _ = populate_xref_impl(data, prev as usize, insert_map)?;
+        let _ = populate_xref_impl_inner(data, prev as usize, insert_map, visited)?;
     }
 
     let size = stream.dict().get::<u32>(SIZE)?;
@@ -1091,5 +1117,47 @@ fn parse_metadata(info_dict: &Dict<'_>) -> Metadata {
         producer: info_dict
             .get::<object::String<'_>>(PRODUCER)
             .map(|t| t.to_vec()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circular_prev_chain_does_not_stack_overflow() {
+        // Construct a minimal PDF where the xref trailer's PREV pointer
+        // points back to the same xref offset, creating an infinite cycle.
+        // The xref table starts at offset 56. PREV also points to 56.
+        let pdf = b"%PDF-1.0\n\
+                     1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                     xref\n\
+                     0 1\n\
+                     0000000000 65535 f \r\n\
+                     trailer\n<< /Size 1 /Root 1 0 R /Prev 56 >>\n\
+                     startxref\n56\n%%EOF";
+        // This should return an error (or succeed if fallback kicks in),
+        // but must NOT stack overflow.
+        let mut xref_map = FxHashMap::default();
+        let xref_pos = find_last_xref_pos(pdf.as_ref());
+        if let Some(pos) = xref_pos {
+            // The cycle detection should cause this to return None on the
+            // second visit, and then the first call propagates None.
+            let _result = populate_xref_impl(pdf.as_ref(), pos, &mut xref_map);
+        }
+    }
+
+    #[test]
+    fn mutual_prev_cycle_does_not_stack_overflow() {
+        // Test the cycle detection directly by pre-seeding the visited set.
+        let mut xref_map = FxHashMap::default();
+        let mut visited = BTreeSet::new();
+        // Simulate: we already visited offsets 100 and 200
+        visited.insert(100);
+        visited.insert(200);
+        // Attempting to visit 100 again should be detected as a cycle
+        let data = b"%PDF-1.0\n";
+        let result = populate_xref_impl_inner(data.as_ref(), 100, &mut xref_map, &mut visited);
+        assert!(result.is_none(), "circular reference should return None");
     }
 }


### PR DESCRIPTION
Fixes four resource exhaustion paths that can be triggered by crafted PDF input.

## Circular xref PREV chain (hayro-syntax)

`populate_xref_impl()` follows PREV pointers recursively with no cycle detection. A PDF with a circular PREV chain causes unbounded stack recursion.

Fix: track visited offsets in a `BTreeSet<usize>`, reject revisits. Defense-in-depth depth limit of 1024.

## Unbounded stream decompression (hayro-syntax)

`FlateDecode`, LZW, and RunLength decoders call `read_to_end()` with no output size limit. A small compressed stream can decompress to gigabytes.

Fix: 256 MB cap on decompressed output for all three decoders. Chunked reading with size check per iteration.

## Form XObject recursion (hayro-interpret)

`draw_form_xobject()` recurses through `interpret()` with no depth counter. Nested or circular form XObjects cause stack overflow.

Fix: depth counter on `Context` with limit of 100. Checked on entry, decremented on all exit paths.

## Embedded image dimensions (hayro-interpret)

`ImageXObject::new()` reads width/height from the PDF dictionary with no upper bound. A PDF claiming 100k×100k dimensions attempts a 30 GB allocation.

Fix: per-side limit of 65535, total pixel limit of 500M.

## Notes

- No public API changes
- No `unsafe` code
- All existing tests pass