### PR TITLE
hayro-syntax: Remove `skip_in_*` methods

### DIFF
--- a/hayro-syntax/src/object/array.rs
+++ b/hayro-syntax/src/object/array.rs
@@ -78,9 +78,9 @@ impl Skippable for Array<'_> {
             if let Some(()) = r.forward_tag(b"]") {
                 return Some(());
             } else if is_content_stream {
-                r.skip_not_in_content_stream::<Object<'_>>()?;
+                r.skip::<Object<'_>>(true)?;
             } else {
-                r.skip_not_in_content_stream::<MaybeRef<Object<'_>>>()?;
+                r.skip::<MaybeRef<Object<'_>>>(false)?;
             }
         }
     }

--- a/hayro-syntax/src/object/bool.rs
+++ b/hayro-syntax/src/object/bool.rs
@@ -17,7 +17,7 @@ impl Skippable for bool {
 
 impl Readable<'_> for bool {
     fn read(r: &mut Reader<'_>, _: &ReaderContext<'_>) -> Option<Self> {
-        match r.skip_in_content_stream::<Self>()? {
+        match r.skip::<Self>(true)? {
             b"true" => Some(true),
             b"false" => Some(false),
             _ => None,

--- a/hayro-syntax/src/object/indirect.rs
+++ b/hayro-syntax/src/object/indirect.rs
@@ -49,9 +49,9 @@ where
     T: Skippable,
 {
     fn skip(r: &mut Reader<'_>, _: bool) -> Option<()> {
-        r.skip_in_content_stream::<ObjectIdentifier>()?;
+        r.skip::<ObjectIdentifier>(false)?;
         r.skip_white_spaces_and_comments();
-        r.skip_not_in_content_stream::<T>()?;
+        r.skip::<T>(false)?;
         r.skip_white_spaces_and_comments();
         // We are lenient and don't require it.
         r.forward_tag(b"endobj");

--- a/hayro-syntax/src/object/mod.rs
+++ b/hayro-syntax/src/object/mod.rs
@@ -264,9 +264,9 @@ impl Readable<'_> for ObjectIdentifier {
 
 impl Skippable for ObjectIdentifier {
     fn skip(r: &mut Reader<'_>, _: bool) -> Option<()> {
-        r.skip_in_content_stream::<i32>()?;
+        r.skip::<i32>(false)?;
         r.skip_white_spaces_and_comments();
-        r.skip_in_content_stream::<i32>()?;
+        r.skip::<i32>(false)?;
         r.skip_white_spaces_and_comments();
         r.forward_tag(b"obj")?;
 

--- a/hayro-syntax/src/object/ref.rs
+++ b/hayro-syntax/src/object/ref.rs
@@ -39,9 +39,9 @@ impl From<ObjectIdentifier> for ObjRef {
 
 impl Skippable for ObjRef {
     fn skip(r: &mut Reader<'_>, _: bool) -> Option<()> {
-        r.skip_not_in_content_stream::<i32>()?;
+        r.skip::<i32>(false)?;
         r.skip_white_spaces();
-        r.skip_not_in_content_stream::<i32>()?;
+        r.skip::<i32>(false)?;
         r.skip_white_spaces();
         r.forward_tag(b"R")?;
 

--- a/hayro-syntax/src/reader.rs
+++ b/hayro-syntax/src/reader.rs
@@ -14,8 +14,6 @@ pub trait ReaderExt<'a> {
     fn read_with_context<T: Readable<'a>>(&mut self, ctx: &ReaderContext<'a>) -> Option<T>;
     fn read_without_context<T: Readable<'a>>(&mut self) -> Option<T>;
     fn skip<T: Skippable>(&mut self, is_content_stream: bool) -> Option<&'a [u8]>;
-    fn skip_not_in_content_stream<T: Skippable>(&mut self) -> Option<&'a [u8]>;
-    fn skip_in_content_stream<T: Skippable>(&mut self) -> Option<&'a [u8]>;
     fn skip_white_spaces(&mut self);
     fn read_white_space(&mut self) -> Option<()>;
     fn skip_eol_characters(&mut self);
@@ -62,16 +60,6 @@ impl<'a> ReaderExt<'a> for Reader<'a> {
         })?;
 
         self.data.get(old_offset..self.offset)
-    }
-
-    #[inline]
-    fn skip_not_in_content_stream<T: Skippable>(&mut self) -> Option<&'a [u8]> {
-        self.skip::<T>(false)
-    }
-
-    #[inline]
-    fn skip_in_content_stream<T: Skippable>(&mut self) -> Option<&'a [u8]> {
-        self.skip::<T>(false)
     }
 
     #[inline]

--- a/hayro-syntax/src/trivia.rs
+++ b/hayro-syntax/src/trivia.rs
@@ -75,7 +75,7 @@ impl Skippable for Comment<'_> {
 
 impl<'a> Readable<'a> for Comment<'a> {
     fn read(r: &mut Reader<'a>, _: &ReaderContext<'_>) -> Option<Self> {
-        let bytes = r.skip_in_content_stream::<Comment<'_>>()?;
+        let bytes = r.skip::<Comment<'_>>(false)?;
         let bytes = bytes.get(1..bytes.len()).unwrap();
 
         Some(Comment(bytes))

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -568,9 +568,7 @@ impl XRef {
                 } else {
                     // There is a valid object at the offset, it's just not of the type the caller
                     // expected, which is fine.
-                    if r.skip_not_in_content_stream::<IndirectObject<Object<'_>>>()
-                        .is_some()
-                    {
+                    if r.skip::<IndirectObject<Object<'_>>>(false).is_some() {
                         return None;
                     }
                 };


### PR DESCRIPTION
Closes #1184.