### PR TITLE
Don't enable the zlib-rs feature on flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -2422,12 +2421,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ image = { version = "0.25", default-features = false }
 kurbo = { version = "0.13.0" }
 log = { version = "0.4" }
 resvg = { version = "0.47.0" }
-flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
+flate2 = { version = "1"}
 phf = { version = "0.13.1", default-features = false }
 moxcms = { version = "0.8.1" }
 rustc-hash = { version = "2" }


### PR DESCRIPTION
By doing so, users can still explicitly opt in for zlib-rs by adding a direct dependency to `flate2` and enabling the feature. However, if we enable the feature on our side users have no way of forcing the safer miniz-oxide backend on their side instead. Hence, we shouldn't enable it on our side.