### PR TITLE
hayro-syntax: Revert changes to flate decoder

### DIFF
--- a/hayro-syntax/src/filter/lzw_flate.rs
+++ b/hayro-syntax/src/filter/lzw_flate.rs
@@ -330,16 +330,13 @@ pub(crate) mod flate {
                             }
                         }
 
-                        if distance == 0 || distance > self.output.len() {
-                            warn!("invalid flate distance {}", distance);
-
-                            self.eof = true;
-                            return;
-                        }
-
+                        // Copy from previous output
+                        let start = self.output.len().wrapping_sub(distance);
                         for _ in 0..length {
-                            let byte = self.output[self.output.len() - distance];
-                            self.output.push(byte);
+                            if start < self.output.len() {
+                                let byte = self.output[self.output.len() - distance];
+                                self.output.push(byte);
+                            }
                         }
                     }
                 }
@@ -719,13 +716,12 @@ struct PredictorParams {
 }
 
 impl PredictorParams {
-    fn bits_per_pixel(&self) -> Option<usize> {
-        (self.bits_per_component as usize).checked_mul(self.colors as usize)
+    fn bits_per_pixel(&self) -> u8 {
+        self.bits_per_component * self.colors
     }
 
-    fn row_length_in_bytes(&self) -> Option<usize> {
-        let bits_per_row = self.columns.checked_mul(self.bits_per_pixel()?)?;
-        Some(bits_per_row.div_ceil(8))
+    fn row_length_in_bytes(&self) -> usize {
+        (self.columns * self.bits_per_pixel() as usize).div_ceil(8)
     }
 }
 
@@ -759,25 +755,22 @@ fn apply_predictor(data: Vec<u8>, params: &PredictorParams) -> Option<Vec<u8>> {
         i => {
             let is_png_predictor = i >= 10;
 
-            if !matches!(params.bits_per_component, 1 | 2 | 4 | 8 | 16) {
-                warn!("invalid bits per component {}", params.bits_per_component);
-
-                return None;
-            }
-
-            let row_len = params.row_length_in_bytes()?;
-            if row_len == 0 {
-                return None;
-            }
+            let row_len = params.row_length_in_bytes();
 
             let total_row_len = if is_png_predictor {
                 // + 1 Because each row must start with the predictor that is used for PNG predictors.
-                row_len.checked_add(1)?
+                row_len + 1
             } else {
                 row_len
             };
 
             let num_rows = data.len() / total_row_len;
+
+            if !matches!(params.bits_per_component, 1 | 2 | 4 | 8 | 16) {
+                warn!("invalid bits per component {}", params.bits_per_component);
+
+                return None;
+            }
 
             let (bit_size, chunk_len) = if is_png_predictor {
                 (
@@ -790,8 +783,7 @@ fn apply_predictor(data: Vec<u8>, params: &PredictorParams) -> Option<Vec<u8>> {
             let zero_row = vec![0; row_len];
             let mut prev_row = BitChunks::new(&zero_row, bit_size, chunk_len)?;
             let zero_col = BitChunk::new(0, chunk_len);
-            let out_len = num_rows.checked_mul(row_len)?;
-            let mut out = vec![0; out_len];
+            let mut out = vec![0; num_rows * row_len];
             let mut writer = BitWriter::new(&mut out, bit_size)?;
 
             for in_row in data.chunks_exact(total_row_len) {
@@ -1077,18 +1069,5 @@ mod tests {
                 4, 3, 1, 252, 5, 253, 6, 1, 229, 254,
             ],
         );
-    }
-
-    #[test]
-    fn predictor_rejects_overflowing_row_size() {
-        let params = PredictorParams {
-            predictor: 10,
-            colors: 4,
-            bits_per_component: 16,
-            columns: usize::MAX,
-            early_change: false,
-        };
-
-        assert!(apply_predictor(vec![0], &params).is_none());
     }
 }


### PR DESCRIPTION
They broke 3 tests (invalid PDFs, but still), I didn't notice because I didn't rerun the tests back then.