### PR TITLE
Add support for reading image files directly

### DIFF
--- a/hayro-interpret/src/color.rs
+++ b/hayro-interpret/src/color.rs
@@ -283,6 +283,17 @@ impl ColorSpace {
             .collect()
     }
 
+    /// Returns `true` if the color space is a device color space and the `decode_arr` is the
+    /// default decode array for this color space.
+    pub(crate) fn is_default_colors(&self, decode_arr: Option<&[(f32, f32)]>) -> bool {
+        match self.0.as_ref() {
+            ColorSpaceType::DeviceCmyk => decode_arr.is_none_or(|d| d == [(0.0, 1.0); 4]),
+            ColorSpaceType::DeviceGray => decode_arr.is_none_or(|d| d == [(0.0, 1.0); 1]),
+            ColorSpaceType::DeviceRgb => decode_arr.is_none_or(|d| d == [(0.0, 1.0); 3]),
+            _ => false,
+        }
+    }
+
     /// Get the initial color of the color space.
     pub(crate) fn initial_color(&self) -> ColorComponents {
         match self.0.as_ref() {

--- a/hayro-interpret/src/types.rs
+++ b/hayro-interpret/src/types.rs
@@ -4,9 +4,10 @@ use crate::pattern::Pattern;
 use crate::soft_mask::SoftMask;
 use crate::util::hash128;
 use crate::x_object::ImageXObject;
-use hayro_syntax::object::Stream;
+use hayro_syntax::object::stream::{ImageFormat, ImageFormats, Stream};
 use kurbo::{Affine, BezPath, Cap, Join};
 use smallvec::{SmallVec, smallvec};
+use std::borrow::Cow;
 
 /// A clip path.
 #[derive(Debug, Clone)]
@@ -69,7 +70,7 @@ impl CacheKey for StencilImage<'_, '_> {
 /// A raster image.
 pub struct RasterImage<'a>(pub(crate) ImageXObject<'a>);
 
-impl RasterImage<'_> {
+impl<'a> RasterImage<'a> {
     /// Perform some operation with the RGB and alpha channel of the image.
     ///
     /// The second argument allows you to give the image decoder a hint for
@@ -82,9 +83,21 @@ impl RasterImage<'_> {
         func: impl FnOnce(ImageData, Option<LumaData>),
         target_dimension: Option<(u32, u32)>,
     ) {
-        if let Some(decoded) = self.0.decoded_raster(target_dimension) {
-            func(decoded.image, decoded.alpha);
+        match self.to_file(target_dimension, ImageFormats::default()) {
+            Some(ImageFileOrData::File(_)) => unreachable!(),
+            Some(ImageFileOrData::Data { image, alpha }) => func(image, alpha),
+            None => {}
         }
+    }
+
+    /// Get the data of the image. If an image of a desired format is stored in the stream, it uses
+    /// that; otherwise, it decodes and returns raw samples.
+    pub fn to_file(
+        &self,
+        target_dimension: Option<(u32, u32)>,
+        formats: ImageFormats,
+    ) -> Option<ImageFileOrData<'a>> {
+        self.0.decoded_raster(target_dimension, formats)
     }
 
     /// Return the underlying stream object.
@@ -245,6 +258,42 @@ impl ImageData {
             Self::Luma(d) => d.scale_factors,
         }
     }
+}
+
+/// A structure holding image file data.
+#[derive(Clone)]
+pub struct ImageFile<'a> {
+    /// The actual data. It is encoded in the specified file format.
+    pub data: Cow<'a, [u8]>,
+    /// The format the data is encoded in. This is guaranteed to be one of the formats enabled in
+    /// [`RasterImage::to_file`].
+    pub format: ImageFormat,
+    /// The width.
+    ///
+    /// This is not necessarily the intrinsic width of the image, if the PDF provided wrong
+    /// metadata.
+    pub width: u32,
+    /// The height.
+    ///
+    /// This is not necessarily the intrinsic height of the image, if the PDF provided wrong
+    /// metadata.
+    pub height: u32,
+    /// Whether the image should be interpolated.
+    pub interpolate: bool,
+}
+
+/// Either an image file, or raw image samples.
+#[derive(Clone)]
+pub enum ImageFileOrData<'a> {
+    /// An image file in the given format.
+    File(ImageFile<'a>),
+    /// Image samples.
+    Data {
+        /// The RGB or greyscale samples.
+        image: ImageData,
+        /// The alpha channel, if there is one.
+        alpha: Option<LumaData>,
+    },
 }
 
 /// A type of paint.

--- a/hayro-interpret/src/x_object.rs
+++ b/hayro-interpret/src/x_object.rs
@@ -4,9 +4,12 @@ use crate::context::Context;
 use crate::device::Device;
 use crate::function::{Function, interpolate};
 use crate::interpret::state::ActiveTransferFunction;
-use crate::{BlendMode, CacheKey, ClipPath, Image, ImageDrawProps, RasterImage, StencilImage};
+use crate::{
+    BlendMode, CacheKey, ClipPath, Image, ImageDrawProps, ImageFileOrData, RasterImage,
+    StencilImage,
+};
 use crate::{FillRule, InterpreterWarning, WarningSinkFn, interpret};
-use crate::{ImageData, LumaData, RgbData};
+use crate::{ImageData, ImageFile, LumaData, RgbData};
 use hayro_syntax::bit_reader::BitReader;
 use hayro_syntax::content::TypedIter;
 use hayro_syntax::object::Array;
@@ -15,7 +18,9 @@ use hayro_syntax::object::Name;
 use hayro_syntax::object::Object;
 use hayro_syntax::object::Stream;
 use hayro_syntax::object::dict::keys::*;
-use hayro_syntax::object::stream::{FilterResult, ImageColorSpace, ImageDecodeParams};
+use hayro_syntax::object::stream::{
+    FilterResult, ImageColorSpace, ImageDecodeParams, ImageFormat, ImageFormats,
+};
 use hayro_syntax::page::Resources;
 use kurbo::{Affine, Rect, Shape};
 use smallvec::{SmallVec, smallvec};
@@ -349,12 +354,13 @@ impl<'a> ImageXObject<'a> {
     pub(crate) fn decoded_raster(
         &self,
         target_dimension: Option<(u32, u32)>,
-    ) -> Option<DecodedRaster> {
+        formats: ImageFormats,
+    ) -> Option<ImageFileOrData<'a>> {
         if self.is_mask {
             return None;
         }
 
-        decode_raster(self, target_dimension)
+        decode_raster(self, target_dimension, formats)
     }
 
     pub(crate) fn width(&self) -> u32 {
@@ -380,12 +386,12 @@ pub(crate) struct DecodedMask {
     pub(crate) luma: LumaData,
 }
 
-pub(crate) struct DecodedRaster {
-    pub(crate) image: ImageData,
-    pub(crate) alpha: Option<LumaData>,
+enum DecodeContext<'a> {
+    File(Cow<'a, [u8]>, ImageFormat),
+    Data(DecodeContextData<'a>),
 }
 
-struct DecodeContext<'a> {
+struct DecodeContextData<'a> {
     decoded: FilterResult<'a>,
     width: u32,
     height: u32,
@@ -398,6 +404,7 @@ struct DecodeContext<'a> {
 fn decode_context<'a>(
     obj: &ImageXObject<'a>,
     target_dimension: Option<(u32, u32)>,
+    mut formats: ImageFormats,
 ) -> Option<DecodeContext<'a>> {
     let dict = obj.stream.dict();
     let dict_bpc = dict
@@ -405,6 +412,27 @@ fn decode_context<'a>(
         .or_else(|| dict.get::<u8>(BITS_PER_COMPONENT));
     let color_space = obj.color_space.clone();
     let is_indexed = obj.color_space.as_ref().is_some_and(|cs| cs.is_indexed());
+
+    let decode_arr = dict
+        .get::<Array<'_>>(D)
+        .or_else(|| dict.get::<Array<'_>>(DECODE))
+        .map(|a| a.iter::<(f32, f32)>().collect::<SmallVec<[_; 4]>>());
+
+    // If any of the following are true:
+    // - There is a non-default color space
+    // - The decode array is non-default for the color space
+    // - The image has a mask
+    // - There is a transfer function
+    // then we can't return an image file.
+    if color_space
+        .as_ref()
+        .is_some_and(|c| !c.is_default_colors(decode_arr.as_deref()))
+        || (!dict.contains_key(SMASK_IN_DATA)
+            && (dict.contains_key(SMASK) || dict.contains_key(MASK)))
+        || obj.transfer_function.is_some()
+    {
+        formats = ImageFormats::default();
+    }
 
     let decode_params = ImageDecodeParams {
         is_indexed,
@@ -415,11 +443,17 @@ fn decode_context<'a>(
         height: obj.height,
     };
 
-    let decoded = obj
+    let decoded = match obj
         .stream
-        .decoded_image(&decode_params)
+        .decoded_image_file(&decode_params, formats)
         .map_err(|_| (obj.warning_sink)(InterpreterWarning::ImageDecodeFailure))
-        .ok()?;
+        .ok()?
+    {
+        hayro_syntax::object::stream::ImageFile::File { data, format } => {
+            return Some(DecodeContext::File(data, format));
+        }
+        hayro_syntax::object::stream::ImageFile::FilterResult(decoded) => decoded,
+    };
 
     let (mut scale_x, mut scale_y) = (1.0, 1.0);
 
@@ -460,13 +494,10 @@ fn decode_context<'a>(
         .or(dict_bpc)
         .unwrap_or(fallback_bpc);
 
-    let decode_arr = dict
-        .get::<Array<'_>>(D)
-        .or_else(|| dict.get::<Array<'_>>(DECODE))
-        .map(|a| a.iter::<(f32, f32)>().collect::<SmallVec<_>>())
-        .unwrap_or(color_space.default_decode_arr(bits_per_component as f32));
+    let decode_arr =
+        decode_arr.unwrap_or(color_space.default_decode_arr(bits_per_component as f32));
 
-    Some(DecodeContext {
+    Some(DecodeContext::Data(DecodeContextData {
         decoded,
         width,
         height,
@@ -474,14 +505,17 @@ fn decode_context<'a>(
         color_space,
         bits_per_component,
         decode_arr,
-    })
+    }))
 }
 
 fn decode_mask(
     obj: &ImageXObject<'_>,
     target_dimension: Option<(u32, u32)>,
 ) -> Option<DecodedMask> {
-    let ctx = decode_context(obj, target_dimension)?;
+    let DecodeContext::Data(ctx) = decode_context(obj, target_dimension, ImageFormats::default())?
+    else {
+        unreachable!()
+    };
     let mut height = ctx.height;
 
     let data = decode_mask_bytes(
@@ -511,11 +545,23 @@ fn decode_mask(
     })
 }
 
-fn decode_raster(
-    obj: &ImageXObject<'_>,
+fn decode_raster<'a>(
+    obj: &ImageXObject<'a>,
     target_dimension: Option<(u32, u32)>,
-) -> Option<DecodedRaster> {
-    let mut ctx = decode_context(obj, target_dimension)?;
+    formats: ImageFormats,
+) -> Option<ImageFileOrData<'a>> {
+    let mut ctx = match decode_context(obj, target_dimension, formats)? {
+        DecodeContext::File(data, format) => {
+            return Some(ImageFileOrData::File(ImageFile {
+                data,
+                format,
+                width: obj.width,
+                height: obj.height,
+                interpolate: obj.interpolate,
+            }));
+        }
+        DecodeContext::Data(ctx) => ctx,
+    };
     let mut height = ctx.height;
 
     let is_default_decode = ctx.decode_arr
@@ -664,7 +710,7 @@ fn decode_raster(
         .flatten()
     };
 
-    Some(DecodedRaster { image, alpha })
+    Some(ImageFileOrData::Data { image, alpha })
 }
 
 fn decode_mask_bytes(

--- a/hayro-syntax/src/filter/dct.rs
+++ b/hayro-syntax/src/filter/dct.rs
@@ -98,10 +98,6 @@ pub(crate) fn decode(
     })
 }
 
-pub(crate) fn is_default_params(params: &Dict<'_>) -> bool {
-    params.get::<u8>(COLOR_TRANSFORM).is_none_or(|c| c == 1)
-}
-
 fn maybe_patch_jpeg_dimensions<'a>(
     data: &'a [u8],
     image_params: &ImageDecodeParams,

--- a/hayro-syntax/src/filter/dct.rs
+++ b/hayro-syntax/src/filter/dct.rs
@@ -98,6 +98,10 @@ pub(crate) fn decode(
     })
 }
 
+pub(crate) fn is_default_params(params: &Dict<'_>) -> bool {
+    params.get::<u8>(COLOR_TRANSFORM).is_none_or(|c| c == 1)
+}
+
 fn maybe_patch_jpeg_dimensions<'a>(
     data: &'a [u8],
     image_params: &ImageDecodeParams,

--- a/hayro-syntax/src/filter/mod.rs
+++ b/hayro-syntax/src/filter/mod.rs
@@ -17,7 +17,9 @@ mod run_length;
 use crate::object::Dict;
 use crate::object::Name;
 use crate::object::dict::keys::*;
-use crate::object::stream::{DecodeFailure, FilterResult, ImageDecodeParams};
+use crate::object::stream::{
+    DecodeFailure, FilterResult, ImageDecodeParams, ImageFormat, ImageFormats,
+};
 use core::ops::Deref;
 
 /// A data filter.
@@ -130,5 +132,15 @@ impl Filter {
         }
 
         res
+    }
+
+    pub(crate) fn as_format(self, formats: ImageFormats, params: &Dict<'_>) -> Option<ImageFormat> {
+        match self {
+            Self::DctDecode if formats.jpeg && dct::is_default_params(params) => {
+                Some(ImageFormat::Jpeg)
+            }
+            Self::JpxDecode if formats.jpeg_2000 => Some(ImageFormat::Jpeg2000),
+            _ => None,
+        }
     }
 }

--- a/hayro-syntax/src/filter/mod.rs
+++ b/hayro-syntax/src/filter/mod.rs
@@ -136,7 +136,9 @@ impl Filter {
 
     pub(crate) fn as_format(self, formats: ImageFormats, params: &Dict<'_>) -> Option<ImageFormat> {
         match self {
-            Self::DctDecode if formats.jpeg && dct::is_default_params(params) => {
+            Self::DctDecode
+                if formats.jpeg && params.get::<u8>(COLOR_TRANSFORM).is_none_or(|c| c == 1) =>
+            {
                 Some(ImageFormat::Jpeg)
             }
             Self::JpxDecode if formats.jpeg_2000 => Some(ImageFormat::Jpeg2000),

--- a/hayro-syntax/src/object/stream.rs
+++ b/hayro-syntax/src/object/stream.rs
@@ -167,28 +167,42 @@ impl<'a> Stream<'a> {
         &self,
         image_params: &ImageDecodeParams,
     ) -> Result<FilterResult<'a>, DecodeFailure> {
+        match self.decoded_image_file(image_params, ImageFormats::default())? {
+            ImageFile::File { .. } => unreachable!(),
+            ImageFile::FilterResult(result) => Ok(result),
+        }
+    }
+
+    /// Return the decoded data of the stream, or an image file of a desired format if one is
+    /// stored in the stream.
+    pub fn decoded_image_file(
+        &self,
+        image_params: &ImageDecodeParams,
+        formats: ImageFormats,
+    ) -> Result<ImageFile<'a>, DecodeFailure> {
         let data = self.raw_data();
         let filters_and_params = self.filters_and_params();
 
-        let mut current: Option<FilterResult<'a>> = None;
+        let mut current: FilterResult<'a> = FilterResult {
+            data,
+            image_data: None,
+        };
 
         for (filter, params) in filters_and_params
             .filters
             .iter()
             .zip(filters_and_params.params.iter())
         {
-            let new = filter.apply(
-                current.as_ref().map(|c| c.data.as_ref()).unwrap_or(&data),
-                params,
-                image_params,
-            )?;
-            current = Some(new);
+            if let Some(format) = filter.as_format(formats, params) {
+                return Ok(ImageFile::File {
+                    data: current.data,
+                    format,
+                });
+            }
+            current = filter.apply(&current.data, params, image_params)?;
         }
 
-        Ok(current.unwrap_or(FilterResult {
-            data,
-            image_data: None,
-        }))
+        Ok(ImageFile::FilterResult(current))
     }
 }
 
@@ -284,6 +298,57 @@ impl FilterResult<'_> {
             image_data: None,
         }
     }
+}
+
+/// A set of image formats that may be returned by [`Stream::decoded_image_file`].
+#[derive(Debug, Default, Clone, Copy)]
+#[non_exhaustive]
+pub struct ImageFormats {
+    /// JPEG.
+    pub jpeg: bool,
+    /// JPEG 2000.
+    pub jpeg_2000: bool,
+}
+
+impl ImageFormats {
+    /// Add JPEG to the set.
+    pub fn jpeg(mut self) -> Self {
+        self.jpeg = true;
+        self
+    }
+
+    /// Add JPEG 2000 to the set.
+    pub fn jpeg_2000(mut self) -> Self {
+        self.jpeg_2000 = true;
+        self
+    }
+}
+
+/// Either an image file in a specific [`ImageFormat`], or a [`FilterResult`].
+///
+/// Returned by [`Stream::decoded_image_file`].
+pub enum ImageFile<'a> {
+    /// An image file.
+    File {
+        /// The encoded image data.
+        data: Cow<'a, [u8]>,
+        /// The format the data is in.
+        ///
+        /// This is guaranteed to be one of the formats enabled in [`ImageFormats`].
+        format: ImageFormat,
+    },
+    /// A `FilterResult` containing raw image samples.
+    FilterResult(FilterResult<'a>),
+}
+
+/// An image format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ImageFormat {
+    /// JPEG.
+    Jpeg,
+    /// JPEG 2000.
+    Jpeg2000,
 }
 
 fn parse_proper<'a>(r: &mut Reader<'a>, dict: &Dict<'a>) -> Option<Stream<'a>> {


### PR DESCRIPTION
I am writing a tool that extracts images from a PDF. `hayro-interpret` currently supports getting the image as an RGBA bitmap, but in the case where the embedded image is an untransformed JPEG (or JPEG 2000), it would be very convenient to be able to get this JPEG directly, bypassing the need for decoding and re-encoding.

I gathered that all the following five conditions need to be true in order to extract a JPEG raw:
1. The JPEG does not have color transform disabled
2. The decode array is the default one
3. There is no transfer function
4. There is no mask
5. There is no colour space, or the colour space is a default one (`Device*`)

I had to learn a lot about PDF to make this PR, so I might be missing some conditions.

The public API is just something I chose that I thought sensible. I’m happy to change to anything else.