### PR TITLE
hayro-interpret: Render annotations with appearance states (checkboxes)

### DIFF
--- a/hayro-interpret/src/interpret/mod.rs
+++ b/hayro-interpret/src/interpret/mod.rs
@@ -17,7 +17,7 @@ use crate::x_object::{
 };
 use hayro_syntax::content::TypedIter;
 use hayro_syntax::content::ops::TypedInstruction;
-use hayro_syntax::object::dict::keys::{ANNOTS, AP, F, MCID, N, OC, RECT};
+use hayro_syntax::object::dict::keys::{ANNOTS, AP, AS, F, MCID, N, OC, RECT};
 use hayro_syntax::object::{Array, Dict, Name, Object, Rect, Stream, dict_or_stream};
 use hayro_syntax::page::{Page, Resources};
 use kurbo::{Affine, Point, Shape};
@@ -155,11 +155,7 @@ pub fn interpret_page<'a>(
                 continue;
             }
 
-            if let Some(apx) = annot
-                .get::<Dict<'_>>(AP)
-                .and_then(|ap| ap.get::<Stream<'_>>(N))
-                .and_then(|o| FormXObject::new(&o))
-            {
+            if let Some(apx) = appearance_stream(&annot).and_then(|o| FormXObject::new(&o)) {
                 let Some(rect) = annot.get::<Rect>(RECT) else {
                     continue;
                 };
@@ -213,6 +209,25 @@ pub fn interpret_page<'a>(
                 context.restore_state(device);
             }
         }
+    }
+}
+
+/// Resolve the normal appearance stream of an annotation.
+///
+/// See 12.5.5. The `N` entry is either a stream, or a dictionary containing
+/// one appearance stream per appearance state (used for example by checkboxes
+/// and radio buttons), in which case the annotation's `AS` entry selects the
+/// applicable one.
+fn appearance_stream<'a>(annot: &Dict<'a>) -> Option<Stream<'a>> {
+    match annot.get::<Dict<'_>>(AP)?.get::<Object<'_>>(N)? {
+        Object::Stream(stream) => Some(stream),
+        Object::Dict(states) => annot
+            .get::<Name<'_>>(AS)
+            .and_then(|state| states.get::<Stream<'_>>(state))
+            // If no valid appearance state is selected, fall back to the
+            // `Off` state (like pdfium and poppler do).
+            .or_else(|| states.get::<Stream<'_>>(b"Off")),
+        _ => None,
     }
 }
 

--- a/hayro-interpret/src/interpret/mod.rs
+++ b/hayro-interpret/src/interpret/mod.rs
@@ -212,20 +212,12 @@ pub fn interpret_page<'a>(
     }
 }
 
-/// Resolve the normal appearance stream of an annotation.
-///
-/// See 12.5.5. The `N` entry is either a stream, or a dictionary containing
-/// one appearance stream per appearance state (used for example by checkboxes
-/// and radio buttons), in which case the annotation's `AS` entry selects the
-/// applicable one.
 fn appearance_stream<'a>(annot: &Dict<'a>) -> Option<Stream<'a>> {
     match annot.get::<Dict<'_>>(AP)?.get::<Object<'_>>(N)? {
         Object::Stream(stream) => Some(stream),
         Object::Dict(states) => annot
             .get::<Name<'_>>(AS)
             .and_then(|state| states.get::<Stream<'_>>(state))
-            // If no valid appearance state is selected, fall back to the
-            // `Off` state (like pdfium and poppler do).
             .or_else(|| states.get::<Stream<'_>>(b"Off")),
         _ => None,
     }

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -12,6 +12,10 @@
     "file": "pdfs/custom/TextClippingModeChanges.pdf"
   },
   {
+    "id": "annotation_checkbox",
+    "file": "pdfs/custom/annotation_checkbox.pdf"
+  },
+  {
     "id": "clip_path_evenodd",
     "file": "pdfs/custom/clip_path_evenodd.pdf"
   },

--- a/hayro-tests/pdfs/custom/annotation_checkbox.pdf
+++ b/hayro-tests/pdfs/custom/annotation_checkbox.pdf
@@ -1,6 +1,6 @@
 %PDF-1.7
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R >>
+<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [7 0 R 8 0 R 9 0 R 10 0 R 11 0 R] /NeedAppearances false >> >>
 endobj
 2 0 obj
 << /Type /Pages /Kids [3 0 R] /Count 1 >>
@@ -9,54 +9,54 @@ endobj
 << /Type /Page /Parent 2 0 R /MediaBox [0 0 160 60] /Resources << >> /Annots [7 0 R 8 0 R 9 0 R 10 0 R 11 0 R] >>
 endobj
 4 0 obj
-<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 31 >>
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 14 14] /Resources << >> /Length 31 >>
 stream
 0 0 1 RG 1 w 0.5 0.5 13 13 re S
 endstream
 endobj
 5 0 obj
-<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 77 >>
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 14 14] /Resources << >> /Length 77 >>
 stream
 0 0 1 RG 1 w 0.5 0.5 13 13 re S 2.5 2.5 m 11.5 11.5 l 2.5 11.5 m 11.5 2.5 l S
 endstream
 endobj
 6 0 obj
-<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 36 >>
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 14 14] /Resources << >> /Length 36 >>
 stream
 0 0.6 0 RG 2 w 2 7 m 6 3 l 12 11 l S
 endstream
 endobj
 7 0 obj
-<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [10 23 24 37] /AS /Yes /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (checked-cross) /F 4 /Rect [10 23 24 37] /V /Yes /AS /Yes /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
 endobj
 8 0 obj
-<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [40 23 54 37] /AS /Off /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (unchecked) /F 4 /Rect [40 23 54 37] /V /Off /AS /Off /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
 endobj
 9 0 obj
-<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [70 23 84 37] /AS /Ja#20wirklich /AP << /N << /Off 4 0 R /Ja#20wirklich 6 0 R >> >> >>
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (checked-custom) /F 4 /Rect [70 23 84 37] /V /Ja#20wirklich /AS /Ja#20wirklich /AP << /N << /Off 4 0 R /Ja#20wirklich 6 0 R >> >> >>
 endobj
 10 0 obj
-<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [100 23 114 37] /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (unchecked-dictcase) /F 4 /Rect [100 23 114 37] /V /Off /AS /Off /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
 endobj
 11 0 obj
-<< /Type /Annot /Subtype /Widget /Rect [130 23 144 37] /AP << /N 6 0 R >> >>
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (direct-normal-appearance) /F 4 /Rect [130 23 144 37] /V /Yes /AS /Yes /AP << /N 6 0 R >> >>
 endobj
 xref
 0 12
 0000000000 65535 f 
 0000000009 00000 n 
-0000000058 00000 n 
-0000000115 00000 n 
-0000000244 00000 n 
-0000000373 00000 n 
-0000000548 00000 n 
-0000000682 00000 n 
-0000000812 00000 n 
-0000000942 00000 n 
-0000001092 00000 n 
-0000001216 00000 n 
+0000000139 00000 n 
+0000000196 00000 n 
+0000000325 00000 n 
+0000000483 00000 n 
+0000000687 00000 n 
+0000000850 00000 n 
+0000001012 00000 n 
+0000001170 00000 n 
+0000001363 00000 n 
+0000001533 00000 n 
 trailer
 << /Size 12 /Root 1 0 R >>
 startxref
-1309
+1687
 %%EOF

--- a/hayro-tests/pdfs/custom/annotation_checkbox.pdf
+++ b/hayro-tests/pdfs/custom/annotation_checkbox.pdf
@@ -1,0 +1,62 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 160 60] /Resources << >> /Annots [7 0 R 8 0 R 9 0 R 10 0 R 11 0 R] >>
+endobj
+4 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 31 >>
+stream
+0 0 1 RG 1 w 0.5 0.5 13 13 re S
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 77 >>
+stream
+0 0 1 RG 1 w 0.5 0.5 13 13 re S 2.5 2.5 m 11.5 11.5 l 2.5 11.5 m 11.5 2.5 l S
+endstream
+endobj
+6 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 36 >>
+stream
+0 0.6 0 RG 2 w 2 7 m 6 3 l 12 11 l S
+endstream
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [10 23 24 37] /AS /Yes /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [40 23 54 37] /AS /Off /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [70 23 84 37] /AS /Ja#20wirklich /AP << /N << /Off 4 0 R /Ja#20wirklich 6 0 R >> >> >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /Rect [100 23 114 37] /AP << /N << /Off 4 0 R /Yes 5 0 R >> >> >>
+endobj
+11 0 obj
+<< /Type /Annot /Subtype /Widget /Rect [130 23 144 37] /AP << /N 6 0 R >> >>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000244 00000 n 
+0000000373 00000 n 
+0000000548 00000 n 
+0000000682 00000 n 
+0000000812 00000 n 
+0000000942 00000 n 
+0000001092 00000 n 
+0000001216 00000 n 
+trailer
+<< /Size 12 /Root 1 0 R >>
+startxref
+1309
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -3,6 +3,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn InlineAbbreviations() { run_render_test("InlineAbbreviations", "pdfs/custom/InlineAbbreviations.pdf", None); }
 #[test] fn OverlappingGlyphClipping() { run_render_test("OverlappingGlyphClipping", "pdfs/custom/OverlappingGlyphClipping.pdf", None); }
 #[test] fn TextClippingModeChanges() { run_render_test("TextClippingModeChanges", "pdfs/custom/TextClippingModeChanges.pdf", None); }
+#[test] fn annotation_checkbox() { run_render_test("annotation_checkbox", "pdfs/custom/annotation_checkbox.pdf", None); }
 #[test] fn clip_path_evenodd() { run_render_test("clip_path_evenodd", "pdfs/custom/clip_path_evenodd.pdf", None); }
 #[test] fn clip_path_nested() { run_render_test("clip_path_nested", "pdfs/custom/clip_path_nested.pdf", None); }
 #[test] fn color_separation_3() { run_render_test("color_separation_3", "pdfs/custom/color_separation_3.pdf", None); }


### PR DESCRIPTION
The normal appearance in `AP/N` can either be a stream or a dictionary with one appearance stream per appearance state, selected by the annotation's `AS` entry. The latter is used by checkboxes and radio buttons, which were previously not rendered at all. If no valid appearance state is selected, fall back to the `Off` state, like pdfium and poppler do.

I verified the change against ISO 32000-1 and ran the regression tests

My real-world test document with radios and checkboxes now renders correctly