### PR TITLE
hayro-interpret: Implement AGL specification glyph-name mapping

### DIFF
--- a/hayro-interpret/src/font/mod.rs
+++ b/hayro-interpret/src/font/mod.rs
@@ -620,19 +620,71 @@ impl Default for FallbackFontQuery {
     }
 }
 
-/// Convert a glyph name to a Unicode character, if possible.
-/// An incomplete implementation of the Adobe Glyph List Specification
-/// <https://github.com/adobe-type-tools/agl-specification>
-pub(crate) fn glyph_name_to_unicode(name: &str) -> Option<char> {
+/// Convert a glyph name to its Unicode value, if possible.
+/// Implements the mapping algorithm of the Adobe Glyph List Specification
+/// <https://github.com/adobe-type-tools/agl-specification>: the name is
+/// looked up as a whole first; otherwise everything from the first period
+/// on is dropped (variant suffixes like `.case` or `.sc`) and the rest is
+/// split on underscores into components (ligatures like `f_i`), each mapped
+/// through the AGL or its `uniXXXX`/`uXXXX[XX]` forms.
+pub(crate) fn glyph_name_to_unicode(name: &str) -> Option<BfString> {
     if let Some(unicode_str) = glyph_names::get(name) {
-        return unicode_str.chars().next();
+        return bf_string_from_str(unicode_str);
+    }
+    if let Some(c) = unicode_from_name(name) {
+        return Some(BfString::Char(c));
     }
 
-    unicode_from_name(name).or_else(|| {
-        warn!("failed to map glyph name {} to unicode", name);
+    let base = name.split('.').next().unwrap_or(name);
+    let mut out = String::new();
+    for component in base.split('_') {
+        if !push_component(component, &mut out) {
+            warn!("failed to map glyph name {} to unicode", name);
 
-        None
-    })
+            return None;
+        }
+    }
+    bf_string_from_str(&out)
+}
+
+fn push_component(component: &str, out: &mut String) -> bool {
+    if let Some(unicode_str) = glyph_names::get(component) {
+        out.push_str(unicode_str);
+        return true;
+    }
+    if let Some(c) = unicode_from_name(component) {
+        out.push(c);
+        return true;
+    }
+    // `uni` followed by several concatenated 4-digit hex groups.
+    if let Some(hex) = component.strip_prefix("uni")
+        && hex.len() > 4
+        && hex.len() % 4 == 0
+        && hex.bytes().all(|b| b.is_ascii_hexdigit())
+    {
+        let decoded: Option<String> = (0..hex.len())
+            .step_by(4)
+            .map(|i| {
+                u32::from_str_radix(&hex[i..i + 4], 16)
+                    .ok()
+                    .and_then(char::from_u32)
+            })
+            .collect();
+        if let Some(decoded) = decoded {
+            out.push_str(&decoded);
+            return true;
+        }
+    }
+    false
+}
+
+fn bf_string_from_str(s: &str) -> Option<BfString> {
+    let mut chars = s.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) => Some(BfString::Char(c)),
+        (Some(_), Some(_)) => Some(BfString::String(s.to_string())),
+        (None, _) => None,
+    }
 }
 
 pub(crate) fn unicode_from_name(name: &str) -> Option<char> {
@@ -675,4 +727,81 @@ pub(crate) fn normalized_glyph_name(mut name: &str) -> &str {
     }
 
     name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::glyph_name_to_unicode;
+    use hayro_cmap::BfString;
+
+    #[test]
+    fn direct_agl_names() {
+        assert_eq!(glyph_name_to_unicode("A"), Some(BfString::Char('A')));
+        assert_eq!(
+            glyph_name_to_unicode("fi"),
+            Some(BfString::Char('\u{FB01}'))
+        );
+        assert_eq!(glyph_name_to_unicode("hyphen"), Some(BfString::Char('-')));
+    }
+
+    #[test]
+    fn uni_and_u_names() {
+        assert_eq!(glyph_name_to_unicode("uni0041"), Some(BfString::Char('A')));
+        assert_eq!(
+            glyph_name_to_unicode("u1F600"),
+            Some(BfString::Char('\u{1F600}'))
+        );
+    }
+
+    #[test]
+    fn variant_suffixes_are_stripped() {
+        assert_eq!(
+            glyph_name_to_unicode("hyphen.case"),
+            Some(BfString::Char('-'))
+        );
+        assert_eq!(
+            glyph_name_to_unicode("parenleft.case"),
+            Some(BfString::Char('('))
+        );
+        assert_eq!(
+            glyph_name_to_unicode("uni0041.sc"),
+            Some(BfString::Char('A'))
+        );
+    }
+
+    #[test]
+    fn underscore_components_form_ligatures() {
+        assert_eq!(
+            glyph_name_to_unicode("f_i"),
+            Some(BfString::String("fi".to_string()))
+        );
+        assert_eq!(
+            glyph_name_to_unicode("f_f_l"),
+            Some(BfString::String("ffl".to_string()))
+        );
+        assert_eq!(
+            glyph_name_to_unicode("f_i.liga"),
+            Some(BfString::String("fi".to_string()))
+        );
+        assert_eq!(
+            glyph_name_to_unicode("uni0066_uni0069"),
+            Some(BfString::String("fi".to_string()))
+        );
+    }
+
+    #[test]
+    fn multi_group_uni_names() {
+        assert_eq!(
+            glyph_name_to_unicode("uni00660069"),
+            Some(BfString::String("fi".to_string()))
+        );
+    }
+
+    #[test]
+    fn unmappable_names_stay_unmapped() {
+        assert_eq!(glyph_name_to_unicode(".notdef"), None);
+        assert_eq!(glyph_name_to_unicode("g102"), None);
+        assert_eq!(glyph_name_to_unicode("f_g102"), None);
+        assert_eq!(glyph_name_to_unicode(""), None);
+    }
 }

--- a/hayro-interpret/src/font/standard_font.rs
+++ b/hayro-interpret/src/font/standard_font.rs
@@ -6,6 +6,7 @@ use crate::font::{
     Encoding, FontData, FontQuery, glyph_name_to_unicode, normalized_glyph_name, stretch_glyph,
     strip_subset_prefix,
 };
+use hayro_cmap::BfString;
 use hayro_syntax::object::Dict;
 use hayro_syntax::object::Name;
 use hayro_syntax::object::dict::keys::{BASE_FONT, FONT_DESC, FONT_WEIGHT, ITALIC_ANGLE};
@@ -475,7 +476,7 @@ impl StandardKind {
         }
     }
 
-    pub(crate) fn char_code_to_unicode(&self, code: u8) -> Option<char> {
+    pub(crate) fn char_code_to_unicode(&self, code: u8) -> Option<BfString> {
         self.code_to_ps_name(code).and_then(glyph_name_to_unicode)
     }
 

--- a/hayro-interpret/src/font/true_type.rs
+++ b/hayro-interpret/src/font/true_type.rs
@@ -190,11 +190,8 @@ impl TrueTypeFont {
         }
 
         match &self.kind {
-            Kind::Embedded(e) => e
-                .code_to_name(code as u8)
-                .and_then(glyph_name_to_unicode)
-                .map(BfString::Char),
-            Kind::Standard(s) => s.char_code_to_unicode(code as u8).map(BfString::Char),
+            Kind::Embedded(e) => e.code_to_name(code as u8).and_then(glyph_name_to_unicode),
+            Kind::Standard(s) => s.char_code_to_unicode(code as u8),
         }
 
         // TODO: The test PDFs below fail (but mutool can render them correctly).

--- a/hayro-interpret/src/font/type1.rs
+++ b/hayro-interpret/src/font/type1.rs
@@ -118,9 +118,9 @@ impl Type1Font {
 
         let code = char_code as u8;
         match &self.1 {
-            Kind::Standard(s) => s.char_code_to_unicode(code).map(BfString::Char),
-            Kind::Cff(c) => c.char_code_to_unicode(code).map(BfString::Char),
-            Kind::Type1(t) => t.char_code_to_unicode(code).map(BfString::Char),
+            Kind::Standard(s) => s.char_code_to_unicode(code),
+            Kind::Cff(c) => c.char_code_to_unicode(code),
+            Kind::Type1(t) => t.char_code_to_unicode(code),
         }
     }
 }
@@ -238,7 +238,7 @@ impl Type1Kind {
         }
     }
 
-    fn char_code_to_unicode(&self, code: u8) -> Option<char> {
+    fn char_code_to_unicode(&self, code: u8) -> Option<BfString> {
         self.code_to_ps_name(code).and_then(glyph_name_to_unicode)
     }
 }
@@ -335,7 +335,7 @@ impl CffKind {
         }
     }
 
-    fn char_code_to_unicode(&self, code: u8) -> Option<char> {
+    fn char_code_to_unicode(&self, code: u8) -> Option<BfString> {
         self.code_to_ps_name(code).and_then(glyph_name_to_unicode)
     }
 }


### PR DESCRIPTION
## Summary

`glyph_name_to_unicode` currently handles only a flat AGL table lookup plus `uniXXXX`/`uXXXX` forms, and it truncates multi-character AGL values to their first char via `.chars().next()` (e.g. names mapping to multi-codepoint sequences lose everything after the first codepoint). Names that the [Adobe Glyph List Specification](https://github.com/adobe-type-tools/agl-specification) defines algorithmically — variant suffixes like `hyphen.case` / `parenleft.case` and underscore-joined ligature components like `f_i` / `f_f_l` — return `None`, so text extraction via `Glyph::as_unicode` yields U+FFFD for glyphs that are fully recoverable.

This PR implements the spec's mapping algorithm:

- look the name up as a whole first;
- otherwise drop everything from the first period (variant suffixes such as `.case`, `.sc`, `.liga`);
- split the remainder on underscores and resolve each component through the AGL table, `uniXXXX` (including concatenated 4-digit groups such as `uni00660069`), or `uXXXX[XX]`.

The crate-internal helper now returns `Option<BfString>` so multi-character results survive through the `char_code_to_unicode` chain in type1/true_type/standard_font. `Glyph::as_unicode` already returned `Option<BfString>`, so the public API is unchanged — it just returns `Some(...)` in more cases. Names that still can't be mapped (e.g. `/g102`, `.notdef`) intentionally continue to return `None`.

## Real-world motivation

A restaurant-menu PDF with subset Type1/CFF fonts, no ToUnicode CMaps, and `Differences` arrays naming glyphs `/f_i`, `/f_f`, `/f_l`, `/hyphen.case`, `/parenleft.case` lost those glyphs (U+FFFD) on 19 of 48 pages during text extraction; with this change all of them are recovered.

Unit tests cover direct AGL names, `uni`/`u` forms, suffix stripping, underscore ligatures, multi-group `uni` names, and names that must stay unmapped.