### PR TITLE
hayro-write: Copy `Annots` when extracting a page

### DIFF
--- a/hayro-tests/tests/write.rs
+++ b/hayro-tests/tests/write.rs
@@ -1,7 +1,7 @@
 use crate::{load_pdf, run_write_test};
 use hayro_syntax::Pdf;
 use hayro_syntax::object::Stream;
-use hayro_syntax::object::dict::keys::GROUP;
+use hayro_syntax::object::dict::keys::{ANNOTS, AP, GROUP, N, P, RECT, SUBTYPE};
 use hayro_write::ExtractionQuery;
 use pdf_writer::Ref;
 use sitro::Renderer;
@@ -352,6 +352,105 @@ fn write_xobject_contents_array() {
         Renderer::Pdfium,
         false,
     );
+}
+
+/// Build a minimal single-page PDF containing a `Square` annotation whose appearance
+/// stream draws a black square, and whose `/P` entry points back to the page.
+fn pdf_with_annotation() -> Vec<u8> {
+    use pdf_writer::types::AnnotationType;
+    use pdf_writer::{Content, Finish, Rect};
+
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    let annot_id = Ref::new(5);
+    let appearance_id = Ref::new(6);
+
+    let mut pdf = pdf_writer::Pdf::new();
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    pdf.pages(page_tree_id).kids([page_id]).count(1);
+
+    let mut page = pdf.page(page_id);
+    page.media_box(Rect::new(0.0, 0.0, 200.0, 200.0));
+    page.parent(page_tree_id);
+    page.contents(content_id);
+    page.annotations([annot_id]);
+    page.finish();
+
+    pdf.stream(content_id, &Content::new().finish());
+
+    let mut annot = pdf.annotation(annot_id);
+    annot.subtype(AnnotationType::Square);
+    annot.rect(Rect::new(50.0, 50.0, 150.0, 150.0));
+    annot.page(page_id);
+    annot.appearance().normal().stream(appearance_id);
+    annot.finish();
+
+    let mut appearance = Content::new();
+    appearance.rect(0.0, 0.0, 100.0, 100.0);
+    appearance.fill_nonzero();
+    let appearance_content = appearance.finish();
+    pdf.form_xobject(appearance_id, &appearance_content)
+        .bbox(Rect::new(0.0, 0.0, 100.0, 100.0));
+
+    pdf.finish()
+}
+
+#[test]
+fn write_page_with_annotation() {
+    let original = Pdf::new(pdf_with_annotation()).unwrap();
+    let extracted = hayro_write::extract_pages_to_pdf(&original, &[0]);
+    let extracted = Pdf::new(extracted).unwrap();
+
+    // The annotation and its appearance stream must have been copied over.
+    let annot = extracted.pages()[0]
+        .raw()
+        .get::<hayro_syntax::object::Array>(ANNOTS)
+        .expect("extracted page should have an `Annots` entry")
+        .iter::<hayro_syntax::object::Dict>()
+        .next()
+        .expect("`Annots` should contain the annotation");
+    assert_eq!(
+        annot
+            .get::<hayro_syntax::object::Name>(SUBTYPE)
+            .unwrap()
+            .as_ref(),
+        b"Square"
+    );
+    assert!(annot.get::<hayro_syntax::object::Rect>(RECT).is_some());
+    assert!(
+        annot
+            .get::<hayro_syntax::object::Dict>(AP)
+            .unwrap()
+            .get::<Stream>(N)
+            .is_some()
+    );
+
+    // The `/P` entry must not have pulled the original page (tree) into the
+    // extracted document.
+    assert!(annot.get::<hayro_syntax::object::Dict>(P).is_none());
+
+    // The annotation must still render in the extracted document.
+    let original_rendered = crate::render_pdf(&original, "", crate::interpreter_settings(), None);
+    let extracted_rendered = crate::render_pdf(&extracted, "", crate::interpreter_settings(), None);
+
+    let original_image = image::load_from_memory(&original_rendered[0])
+        .unwrap()
+        .into_rgba8();
+    let extracted_image = image::load_from_memory(&extracted_rendered[0])
+        .unwrap()
+        .into_rgba8();
+
+    // Make sure we don't just compare two blank pages.
+    assert!(
+        original_image
+            .pixels()
+            .any(|pixel| pixel.0 == [0, 0, 0, 255])
+    );
+
+    let (_, pixel_diff) = crate::get_diff(&original_image, &extracted_image);
+    assert_eq!(pixel_diff, 0);
 }
 
 #[test]

--- a/hayro-write/src/lib.rs
+++ b/hayro-write/src/lib.rs
@@ -19,7 +19,7 @@ use flate2::write::ZlibEncoder;
 use hayro_syntax::object::Dict;
 use hayro_syntax::object::Object;
 use hayro_syntax::object::dict::keys::{
-    COLORSPACE, EXT_G_STATE, FONT, GROUP, PATTERN, PROPERTIES, SHADING, XOBJECT,
+    ANNOTS, COLORSPACE, EXT_G_STATE, FONT, GROUP, PATTERN, PROPERTIES, SHADING, XOBJECT,
 };
 use hayro_syntax::object::{MaybeRef, ObjRef};
 use hayro_syntax::page::{Page, Resources, Rotation};
@@ -356,6 +356,10 @@ fn write_page(
 
     if let Some(group) = raw_dict.get_raw::<Object<'_>>(GROUP) {
         group.write_direct(pdf_page.insert(Name(GROUP)), ctx);
+    }
+
+    if let Some(annots) = raw_dict.get_raw::<Object<'_>>(ANNOTS) {
+        annots.write_direct(pdf_page.insert(Name(ANNOTS)), ctx);
     }
 
     serialize_resources(page.resources(), ctx, &mut pdf_page);

--- a/hayro-write/src/primitive.rs
+++ b/hayro-write/src/primitive.rs
@@ -1,8 +1,8 @@
 use crate::ExtractionContext;
 use hayro_syntax::object;
 use hayro_syntax::object::dict::keys::{
-    AF, LAST_MODIFIED, LENGTH, METADATA, OC, OPI, PIECE_INFO, PT_DATA, REF, STRUCT_PARENT,
-    STRUCT_PARENTS,
+    AF, LAST_MODIFIED, LENGTH, METADATA, OC, OPI, PAGE, PAGES, PIECE_INFO, PT_DATA, REF,
+    STRUCT_PARENT, STRUCT_PARENTS, TYPE,
 };
 use hayro_syntax::object::{MaybeRef, Null, Number, ObjectIdentifier, Stream};
 use hayro_syntax::object::{Object, array, dict};
@@ -40,7 +40,18 @@ impl WriteDirect for object::ObjRef {
         // don't actually exist in the PDF chunk, which will lead to a panic in krilla when renumbering.
         let valid = *ctx.valid_ref_cache.entry(*self).or_insert_with(|| {
             let id = ObjectIdentifier::new(self.obj_number, self.gen_number);
-            ctx.pdf.xref().get::<Object<'_>>(id).is_some()
+            match ctx.pdf.xref().get::<Object<'_>>(id) {
+                // References to page objects (e.g. via an annotation's `/P` entry or the
+                // target of a link destination) are also written as null objects. Pages
+                // are always rewritten from scratch, so copying an original page object
+                // would pull the whole original page tree into the output.
+                Some(Object::Dict(dict)) => !matches!(
+                    dict.get::<object::Name<'_>>(TYPE).as_deref(),
+                    Some(PAGE) | Some(PAGES)
+                ),
+                Some(_) => true,
+                None => false,
+            }
         });
 
         if valid {


### PR DESCRIPTION
Second finding from the same setup as #1279, same caveats, also came straight from an LLM