### PR TITLE
hayro-write: Allow overriding `/Rotate` when extracting a page

### DIFF
--- a/hayro-tests/tests/write.rs
+++ b/hayro-tests/tests/write.rs
@@ -1,8 +1,9 @@
-use crate::{load_pdf, run_write_test};
+use crate::{get_diff, interpreter_settings, load_pdf, run_write_test};
 use hayro_syntax::Pdf;
 use hayro_syntax::object::Stream;
-use hayro_syntax::object::dict::keys::GROUP;
-use hayro_write::ExtractionQuery;
+use hayro_syntax::object::dict::keys::{GROUP, ROTATE};
+use hayro_write::{ExtractionQuery, Rotation};
+use image::load_from_memory;
 use pdf_writer::Ref;
 use sitro::Renderer;
 
@@ -352,6 +353,134 @@ fn write_xobject_contents_array() {
         Renderer::Pdfium,
         false,
     );
+}
+
+/// Build a single-page PDF with a black square in the bottom-left corner of the
+/// page and the given `/Rotate` entry.
+fn pdf_with_rotation(rotation: i32) -> Vec<u8> {
+    use pdf_writer::{Content, Finish, Rect};
+
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+
+    let mut pdf = pdf_writer::Pdf::new();
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    pdf.pages(page_tree_id).kids([page_id]).count(1);
+
+    let mut page = pdf.page(page_id);
+    page.media_box(Rect::new(0.0, 0.0, 100.0, 100.0));
+    page.parent(page_tree_id);
+    page.contents(content_id);
+    page.rotate(rotation);
+    page.finish();
+
+    let mut content = Content::new();
+    content.rect(0.0, 0.0, 30.0, 30.0);
+    content.fill_nonzero();
+    pdf.stream(content_id, &content.finish());
+
+    pdf.finish()
+}
+
+/// Extract the given queries into a new PDF, like `extract_pages_to_pdf` does.
+fn extract_to_pdf(hayro_pdf: &Pdf, queries: &[ExtractionQuery]) -> Vec<u8> {
+    let mut pdf = pdf_writer::Pdf::new();
+    let mut next_ref = Ref::new(1);
+    let catalog_id = next_ref.bump();
+
+    let extracted = hayro_write::extract(
+        hayro_pdf,
+        Box::new(|| next_ref.bump()),
+        hayro_write::ChunkSettings::default(),
+        |_| {},
+        queries,
+    )
+    .unwrap();
+
+    pdf.catalog(catalog_id)
+        .pages(extracted.page_tree_parent_ref);
+    let count = extracted.root_refs.len();
+    pdf.pages(extracted.page_tree_parent_ref)
+        .kids(extracted.root_refs.iter().map(|r| r.unwrap()))
+        .count(count as i32);
+    pdf.extend(&extracted.chunk);
+
+    pdf.finish()
+}
+
+fn render_first_page(pdf: &Pdf) -> image::RgbaImage {
+    let mut pages = hayro::render_pdf(pdf, 1.0, interpreter_settings(), None).unwrap();
+    load_from_memory(&pages.remove(0).into_png().unwrap())
+        .unwrap()
+        .into_rgba8()
+}
+
+#[test]
+fn write_page_rotation_override() {
+    let original = Pdf::new(pdf_with_rotation(90)).unwrap();
+
+    let extracted = extract_to_pdf(
+        &original,
+        &[ExtractionQuery::new_page(0).with_rotation(Rotation::Flipped)],
+    );
+    let extracted = Pdf::new(extracted).unwrap();
+
+    // The page dictionary must contain exactly one `/Rotate` entry, holding
+    // the overridden value instead of the source page's.
+    let raw = extracted.pages()[0].raw();
+    assert_eq!(
+        raw.entries()
+            .filter(|(name, _)| name.as_ref() == ROTATE)
+            .count(),
+        1
+    );
+    assert_eq!(raw.get::<i32>(ROTATE), Some(180));
+
+    // The extracted page must render exactly like a page that was authored
+    // with `/Rotate 180` in the first place.
+    let expected = Pdf::new(pdf_with_rotation(180)).unwrap();
+    let expected_render = render_first_page(&expected);
+    let extracted_render = render_first_page(&extracted);
+
+    // Sanity check that the rotation was actually applied: the square drawn in
+    // the bottom-left corner of the page must show up in the top-right corner.
+    assert_eq!(
+        extracted_render.get_pixel(85, 15),
+        &image::Rgba([0, 0, 0, 255])
+    );
+    assert_ne!(
+        extracted_render.get_pixel(15, 85),
+        &image::Rgba([0, 0, 0, 255])
+    );
+
+    let (_, pixel_diff) = get_diff(&expected_render, &extracted_render);
+    assert_eq!(pixel_diff, 0);
+}
+
+#[test]
+fn write_page_rotation_without_override() {
+    let original = Pdf::new(pdf_with_rotation(90)).unwrap();
+
+    let extracted = extract_to_pdf(&original, &[ExtractionQuery::new_page(0)]);
+    let extracted = Pdf::new(extracted).unwrap();
+
+    // Without an override, the rotation of the source page is carried over.
+    let raw = extracted.pages()[0].raw();
+    assert_eq!(
+        raw.entries()
+            .filter(|(name, _)| name.as_ref() == ROTATE)
+            .count(),
+        1
+    );
+    assert_eq!(raw.get::<i32>(ROTATE), Some(90));
+
+    let original_render = render_first_page(&original);
+    let extracted_render = render_first_page(&extracted);
+
+    let (_, pixel_diff) = get_diff(&original_render, &extracted_render);
+    assert_eq!(pixel_diff, 0);
 }
 
 #[test]

--- a/hayro-write/src/lib.rs
+++ b/hayro-write/src/lib.rs
@@ -22,7 +22,7 @@ use hayro_syntax::object::dict::keys::{
     COLORSPACE, EXT_G_STATE, FONT, GROUP, PATTERN, PROPERTIES, SHADING, XOBJECT,
 };
 use hayro_syntax::object::{MaybeRef, ObjRef};
-use hayro_syntax::page::{Page, Resources, Rotation};
+use hayro_syntax::page::{Page, Resources};
 use pdf_writer::{Chunk, Content, Filter, Finish, Name, Rect, Ref};
 use rustc_hash::FxHashMap;
 use std::collections::{BTreeMap, HashSet};
@@ -31,6 +31,7 @@ use std::ops::DerefMut;
 
 pub use hayro_syntax;
 use hayro_syntax::Pdf;
+pub use hayro_syntax::page::Rotation;
 pub use pdf_writer::Settings as ChunkSettings;
 
 /// Apply the extraction queries to the given PDF and return the results.
@@ -58,7 +59,7 @@ where
             ExtractionQueryType::XObject => {
                 write_xobject(page, root_ref, &mut write_xobject_group_cs, &mut ctx)
             }
-            ExtractionQueryType::Page => write_page(page, root_ref, query.page_index, &mut ctx),
+            ExtractionQueryType::Page => write_page(page, root_ref, query, &mut ctx),
         };
 
         ctx.root_refs.push(res.map(|_| root_ref));
@@ -96,6 +97,7 @@ pub enum ExtractionQueryType {
 pub struct ExtractionQuery {
     query_type: ExtractionQueryType,
     page_index: usize,
+    rotation: Option<Rotation>,
 }
 
 impl ExtractionQuery {
@@ -104,6 +106,7 @@ impl ExtractionQuery {
         Self {
             query_type: ExtractionQueryType::Page,
             page_index,
+            rotation: None,
         }
     }
 
@@ -112,7 +115,15 @@ impl ExtractionQuery {
         Self {
             query_type: ExtractionQueryType::XObject,
             page_index,
+            rotation: None,
         }
+    }
+
+    /// Override the `/Rotate` entry of the extracted page instead of copying it
+    /// from the source page. Has no effect on `XObject` extraction queries.
+    pub fn with_rotation(mut self, rotation: Rotation) -> Self {
+        self.rotation = Some(rotation);
+        self
     }
 }
 
@@ -213,10 +224,7 @@ pub fn extract_pages_to_pdf(hayro_pdf: &Pdf, page_indices: &[usize]) -> Vec<u8> 
     let mut next_ref = Ref::new(1);
     let requests = page_indices
         .iter()
-        .map(|i| ExtractionQuery {
-            query_type: ExtractionQueryType::Page,
-            page_index: *i,
-        })
+        .map(|i| ExtractionQuery::new_page(*i))
         .collect::<Vec<_>>();
 
     let catalog_id = next_ref.bump();
@@ -253,10 +261,7 @@ pub fn extract_pages_as_xobject_to_pdf(hayro_pdf: &Pdf, page_indices: &[usize]) 
     let catalog_id = next_ref.bump();
     let requests = page_indices
         .iter()
-        .map(|i| ExtractionQuery {
-            query_type: ExtractionQueryType::XObject,
-            page_index: *i,
-        })
+        .map(|i| ExtractionQuery::new_xobject(*i))
         .collect::<Vec<_>>();
 
     let extracted = extract(
@@ -316,13 +321,13 @@ pub fn extract_pages_as_xobject_to_pdf(hayro_pdf: &Pdf, page_indices: &[usize]) 
 fn write_page(
     page: &Page<'_>,
     page_ref: Ref,
-    page_idx: usize,
+    query: &ExtractionQuery,
     ctx: &mut ExtractionContext<'_>,
 ) -> Result<(), ExtractionError> {
     let mut chunk = Chunk::with_settings(ctx.chunk_settings);
     // Note: We can cache content stream references, but _not_ the page references themselves.
     // Acrobat for some reason doesn't like duplicate page references in the page tree.
-    let stream_ref = if let Some(cached) = ctx.cached_content_streams.get(&page_idx) {
+    let stream_ref = if let Some(cached) = ctx.cached_content_streams.get(&query.page_index) {
         *cached
     } else {
         let stream_ref = ctx.new_ref();
@@ -333,7 +338,8 @@ fn write_page(
                 &deflate_encode(page.page_stream().unwrap_or(b"")),
             )
             .filter(Filter::FlateDecode);
-        ctx.cached_content_streams.insert(page_idx, stream_ref);
+        ctx.cached_content_streams
+            .insert(query.page_index, stream_ref);
 
         stream_ref
     };
@@ -343,7 +349,7 @@ fn write_page(
     pdf_page
         .media_box(convert_rect(&page.media_box()))
         .crop_box(convert_rect(&page.crop_box()))
-        .rotate(match page.rotation() {
+        .rotate(match query.rotation.unwrap_or(page.rotation()) {
             Rotation::None => 0,
             Rotation::Horizontal => 90,
             Rotation::Flipped => 180,


### PR DESCRIPTION
When extracting pages from a source document, I want to change their orientation at the same time. A typical case is scanned documents where individual pages are stored with the wrong rotation. Currently `write_page` always copies the source page's `/Rotate` entry, so the only way to fix the orientation is to post-process the written PDF.

This adds an optional, typed override on ExtractionQuery, which is already where a single extraction is configured:

`ExtractionQuery::new_page(idx).with_rotation(Rotation::Flipped)`

When set, the override is written instead of the source page's rotation, so the page dictionary still contains exactly one `/Rotate` entry. Reusing `hayro_syntax::page::Rotation` keeps values a multiple of 90 by construction. I considered a callback in the style of `write_xobject_group_cs`, but unlike `Group`, page dict entries are copied from the source page, so appending entries from a callback could produce duplicate keys. The query-level override avoids that