### PR TITLE
hayro: Add SIMD flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }
 zune-jpeg = { version = "0.5", default-features = false }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "8442ef4", default-features = false, features = ["std", "png", "u8_pipeline"] }
-pic-scale = { version = "0.7.9", default-features = false, features = ["neon", "rdm", "sse", "avx"] }
+pic-scale = { version = "0.7.9", default-features = false }
 fearless_simd = "0.4.0"
 brotli = { version = "8", default-features = false, features = ["std"] }
 memchr = { version = "2.8.0", default-features = false, features = ["alloc"] }

--- a/hayro/Cargo.toml
+++ b/hayro/Cargo.toml
@@ -22,11 +22,13 @@ rustc-hash = { workspace = true }
 log = { workspace = true }
 
 [features]
-default = ["embed-fonts", "embed-cmaps"]
+default = ["embed-fonts", "embed-cmaps", "simd"]
 embed-fonts = ["hayro-interpret/embed-fonts"]
 # Embed the 61 predefined cmaps into the binary. Adds about ~250KB of brotli-encoded data.
 embed-cmaps = ["hayro-interpret/embed-cmaps"]
 logging = ["hayro-interpret/logging"]
+# Enable SIMD-accelerated image resizing in pic-scale.
+simd = ["pic-scale/neon", "pic-scale/rdm", "pic-scale/sse", "pic-scale/avx"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Adds a default-enabled `simd` feature for pic-scale’s SIMD acceleration.

Consumers can disable it when consistent raster output across CPU implementations is more important than resizing performance.