### PR TITLE
Add configurable resource limits (stream decompression, image dimensions)

### DIFF
--- a/hayro-interpret/src/log.rs
+++ b/hayro-interpret/src/log.rs
@@ -1,5 +1,18 @@
 //! Logging macros that optionally forward to the `log` crate.
 
+macro_rules! debug {
+    ($fmt:literal $(, $($arg:expr),* $(,)?)?) => {{
+        #[cfg(feature = "logging")]
+        {
+            ::log::debug!($fmt $(, $($arg),*)?);
+        }
+        #[cfg(not(feature = "logging"))]
+        {
+            $($(let _ = &$arg;)*)?
+        }
+    }};
+}
+
 macro_rules! error {
     ($fmt:literal $(, $($arg:expr),* $(,)?)?) => {{
         #[cfg(feature = "logging")]

--- a/hayro-interpret/src/x_object/decode/mod.rs
+++ b/hayro-interpret/src/x_object/decode/mod.rs
@@ -64,6 +64,14 @@ fn decode_context<'a>(
         })
         .unwrap_or((obj.width, obj.height));
 
+    // For codec-driven formats the decoded dimensions come from the codestream
+    // rather than the (already-checked) image dictionary, and they size the
+    // sample buffers below. Enforce the limit against the actual dimensions.
+    if !obj.stream.limits().permits_image(width, height) {
+        debug!("decoded image {width}x{height} exceeds the configured limits");
+        return None;
+    }
+
     let color_space = color_space
         .or_else(|| {
             decoded

--- a/hayro-interpret/src/x_object/image.rs
+++ b/hayro-interpret/src/x_object/image.rs
@@ -146,6 +146,15 @@ impl<'a> ImageXObject<'a> {
             return None;
         }
 
+        // Reject dimension claims beyond the configured limits before any
+        // decode work: decode-time allocations are proportional to the
+        // claimed pixel count, so a tiny crafted dictionary can otherwise
+        // request a multi-gigabyte allocation.
+        if !stream.limits().permits_image(width, height) {
+            debug!("image dimensions {width}x{height} exceed the configured limits");
+            return None;
+        }
+
         Some(Self {
             width,
             cache: cache.clone(),

--- a/hayro-syntax/src/filter/ccitt.rs
+++ b/hayro-syntax/src/filter/ccitt.rs
@@ -1,3 +1,4 @@
+use crate::limits::Limits;
 use crate::object::Dict;
 use crate::object::dict::keys::{
     BLACK_IS_1, COLUMNS, ENCODED_BYTE_ALIGN, END_OF_BLOCK, END_OF_LINE, K, ROWS,
@@ -13,11 +14,21 @@ pub(crate) fn decode(
     data: &[u8],
     params: &Dict<'_>,
     image_params: &ImageDecodeParams,
+    limits: Limits,
 ) -> Option<FilterResult<'static>> {
     let k = params.get::<i32>(K).unwrap_or(0);
 
     let columns = params.get::<usize>(COLUMNS).unwrap_or(1728) as u32;
     let rows = params.get::<u32>(ROWS).unwrap_or(image_params.height);
+
+    // `columns`/`rows` come from the decode parameters, independent of the
+    // image dictionary's dimensions, and size the output buffer below — so
+    // enforce the limit against them directly.
+    if !limits.permits_image(columns, rows) {
+        debug!("CCITT image {columns}x{rows} exceeds the configured limits");
+        return None;
+    }
+
     let output_len = (columns as usize).checked_mul(rows as usize)?;
     let end_of_block = params.get::<bool>(END_OF_BLOCK).unwrap_or(true);
 
@@ -170,6 +181,7 @@ pub(crate) fn decode(
 #[cfg(test)]
 mod tests {
     use super::decode;
+    use crate::limits::{Limit, Limits};
     use crate::object::FromBytes;
     use crate::object::dict::Dict;
     use crate::object::stream::ImageDecodeParams;
@@ -178,9 +190,27 @@ mod tests {
     fn issue1258() {
         let params = Dict::from_bytes(b"<< /K 0 /Columns 8 /Rows 1 >>").unwrap();
 
-        let decoded = decode(&[0x35, 0x14], &params, &ImageDecodeParams::default()).unwrap();
+        let decoded = decode(
+            &[0x35, 0x14],
+            &params,
+            &ImageDecodeParams::default(),
+            Limits::default(),
+        )
+        .unwrap();
 
         assert_eq!(decoded.data.as_ref(), &[0; 8]);
         assert_eq!(decoded.image_data.unwrap().height, 1);
+    }
+
+    #[test]
+    fn rejects_oversized_dimensions() {
+        // `columns * rows` sizes the output buffer independently of the image
+        // dictionary, so an absurd /Columns must be refused under a limit.
+        let params = Dict::from_bytes(b"<< /K 0 /Columns 100000 /Rows 100000 >>").unwrap();
+        let limits = Limits {
+            max_image_pixels: Limit::AtMost(1_000_000),
+            ..Limits::default()
+        };
+        assert!(decode(&[0x00], &params, &ImageDecodeParams::default(), limits).is_none());
     }
 }

--- a/hayro-syntax/src/filter/dct.rs
+++ b/hayro-syntax/src/filter/dct.rs
@@ -1,3 +1,4 @@
+use crate::limits::Limits;
 use crate::object::Dict;
 use crate::object::dict::keys::COLOR_TRANSFORM;
 use crate::object::stream::{FilterResult, ImageColorSpace, ImageData, ImageDecodeParams};
@@ -12,8 +13,19 @@ pub(crate) fn decode(
     data: &[u8],
     params: &Dict<'_>,
     image_params: &ImageDecodeParams,
+    limits: Limits,
 ) -> Option<FilterResult<'static>> {
     if image_params.width > u16::MAX as u32 || image_params.height > u16::MAX as u32 {
+        return None;
+    }
+
+    // The JPEG's own SOF dimensions are clamped down to these below, so the
+    // dictionary dimensions bound the decode; enforce the limit against them.
+    if !limits.permits_image(image_params.width, image_params.height) {
+        debug!(
+            "JPEG image {}x{} exceeds the configured limits",
+            image_params.width, image_params.height
+        );
         return None;
     }
 

--- a/hayro-syntax/src/filter/jbig2.rs
+++ b/hayro-syntax/src/filter/jbig2.rs
@@ -1,4 +1,5 @@
 use crate::bit_reader::BitWriter;
+use crate::limits::Limits;
 use crate::object::Dict;
 use crate::object::Stream;
 use crate::object::dict::keys::JBIG2_GLOBALS;
@@ -15,12 +16,24 @@ pub(crate) fn decode(
     data: &[u8],
     params: &Dict<'_>,
     image_params: &ImageDecodeParams,
+    limits: Limits,
 ) -> Option<FilterResult<'static>> {
     let globals = params
         .get::<Stream<'_>>(JBIG2_GLOBALS)
         .and_then(|g| g.decoded().ok());
 
     let image = hayro_jbig2::Image::new_embedded(data, globals.as_deref()).ok()?;
+
+    // The image dimensions come from the JBIG2 codestream, not the image
+    // dictionary, and size the output buffers below.
+    if !limits.permits_image(image.width(), image.height()) {
+        debug!(
+            "JBIG2 image {}x{} exceeds the configured limits",
+            image.width(),
+            image.height()
+        );
+        return None;
+    }
 
     // Whenever possible (if we don't have an indexed color space), we convert
     // the data as 8-bit instead of 1-bit, so that it can be easier converted

--- a/hayro-syntax/src/filter/jpx.rs
+++ b/hayro-syntax/src/filter/jpx.rs
@@ -1,5 +1,6 @@
 use crate::bit_reader::BitWriter;
 use crate::filter::FilterResult;
+use crate::limits::Limits;
 use crate::math::round_f32;
 use crate::object::stream::{ImageColorSpace, ImageData, ImageDecodeParams};
 use alloc::borrow::Cow;
@@ -18,7 +19,11 @@ impl ImageColorSpace {
     }
 }
 
-pub(crate) fn decode(data: &[u8], params: &ImageDecodeParams) -> Option<FilterResult<'static>> {
+pub(crate) fn decode(
+    data: &[u8],
+    params: &ImageDecodeParams,
+    limits: Limits,
+) -> Option<FilterResult<'static>> {
     use crate::object::stream::ImageColorSpace;
 
     let settings = DecodeSettings {
@@ -31,6 +36,13 @@ pub(crate) fn decode(data: &[u8], params: &ImageDecodeParams) -> Option<FilterRe
 
     let width = image.width();
     let height = image.height();
+
+    // The dimensions come from the JPEG 2000 codestream (which may be tiled),
+    // not the image dictionary, and size the decode buffers below.
+    if !limits.permits_image(width, height) {
+        debug!("JPEG 2000 image {width}x{height} exceeds the configured limits");
+        return None;
+    }
     let bpc = params.bpc.unwrap_or(image.original_bit_depth());
     let cs = match image.color_space() {
         ColorSpace::Gray => ImageColorSpace::Gray,

--- a/hayro-syntax/src/filter/lzw_flate.rs
+++ b/hayro-syntax/src/filter/lzw_flate.rs
@@ -11,36 +11,87 @@ pub(crate) mod flate {
     use crate::object::Dict;
 
     #[cfg(feature = "unsafe")]
-    pub(crate) fn decode(data: &[u8], params: &Dict<'_>) -> Option<Vec<u8>> {
+    pub(crate) fn decode(
+        data: &[u8],
+        params: &Dict<'_>,
+        max_decoded: Option<usize>,
+    ) -> Option<Vec<u8>> {
         use flate2::read::{DeflateDecoder, ZlibDecoder};
         use std::io::Read;
 
-        fn zlib_stream(data: &[u8]) -> Option<Vec<u8>> {
-            let mut decoder = ZlibDecoder::new(data);
-            let mut result = Vec::new();
-            decoder.read_to_end(&mut result).ok().map(|_| result)
+        /// The result of one flate2 inflate attempt. Distinguishing "too large"
+        /// (a definitive rejection) from "this decoder could not handle the
+        /// stream" (try another) keeps an over-limit stream from falling
+        /// through to the fallback decoder and being inflated a second time.
+        enum Inflated {
+            Ok(Vec<u8>),
+            TooLarge,
+            Failed,
         }
 
-        fn deflate_stream(data: &[u8]) -> Option<Vec<u8>> {
-            let mut decoder = DeflateDecoder::new(data);
+        // The decoder is capped at one byte past the limit, so an over-limit
+        // stream is detected (and rejected) rather than silently truncated.
+        fn inflate<R: Read>(mut decoder: R, cap: usize) -> Inflated {
             let mut result = Vec::new();
-            decoder.read_to_end(&mut result).ok().map(|_| result)
+            match decoder.read_to_end(&mut result) {
+                Ok(_) if result.len() <= cap => Inflated::Ok(result),
+                Ok(_) => Inflated::TooLarge,
+                Err(_) => Inflated::Failed,
+            }
         }
 
-        let decoded = zlib_stream(data)
-            .or_else(|| deflate_stream(data))
-            .or_else(|| {
+        fn zlib_stream(data: &[u8], cap: usize) -> Inflated {
+            inflate(
+                ZlibDecoder::new(data).take(cap.saturating_add(1) as u64),
+                cap,
+            )
+        }
+
+        fn deflate_stream(data: &[u8], cap: usize) -> Inflated {
+            inflate(
+                DeflateDecoder::new(data).take(cap.saturating_add(1) as u64),
+                cap,
+            )
+        }
+
+        let cap = max_decoded.unwrap_or(usize::MAX);
+
+        let mut decoded = None;
+        for attempt in [zlib_stream, deflate_stream] {
+            match attempt(data, cap) {
+                Inflated::Ok(v) => {
+                    decoded = Some(v);
+                    break;
+                }
+                // A definitive rejection: retrying with another decoder would
+                // only hit the same limit, so don't fall through.
+                Inflated::TooLarge => {
+                    debug!("flate stream exceeds the decoded-size limit");
+                    return None;
+                }
+                Inflated::Failed => continue,
+            }
+        }
+
+        let decoded = match decoded {
+            Some(v) => v,
+            None => {
                 warn!("flate stream is broken, decoding with fallback");
+                fallback::decode(data, max_decoded)?
+            }
+        };
 
-                fallback::decode(data)
-            })?;
         let params = PredictorParams::from_params(params);
         apply_predictor(decoded, &params)
     }
 
     #[cfg(not(feature = "unsafe"))]
-    pub(crate) fn decode(data: &[u8], params: &Dict<'_>) -> Option<Vec<u8>> {
-        let decoded = fallback::decode(data)?;
+    pub(crate) fn decode(
+        data: &[u8],
+        params: &Dict<'_>,
+        max_decoded: Option<usize>,
+    ) -> Option<Vec<u8>> {
+        let decoded = fallback::decode(data, max_decoded)?;
         let params = PredictorParams::from_params(params);
         apply_predictor(decoded, &params)
     }
@@ -51,11 +102,11 @@ pub(crate) mod flate {
         use alloc::vec;
         use alloc::vec::Vec;
 
-        pub(crate) fn decode(data: &[u8]) -> Option<Vec<u8>> {
-            flate_decode(data)
+        pub(crate) fn decode(data: &[u8], max_decoded: Option<usize>) -> Option<Vec<u8>> {
+            flate_decode(data, max_decoded)
         }
 
-        fn flate_decode(data: &[u8]) -> Option<Vec<u8>> {
+        fn flate_decode(data: &[u8], max_decoded: Option<usize>) -> Option<Vec<u8>> {
             if data.len() >= 2 {
                 let cmf = data[0];
                 let flg = data[1];
@@ -64,12 +115,12 @@ pub(crate) mod flate {
                     && ((cmf as u16) << 8 | flg as u16).is_multiple_of(31)
                     && (flg & 0x20) == 0
                 {
-                    let mut stream = FlateStream::new(&data[2..]);
+                    let mut stream = FlateStream::new(&data[2..], max_decoded);
                     return stream.decode();
                 }
             }
 
-            let mut stream = FlateStream::new(data);
+            let mut stream = FlateStream::new(data, max_decoded);
             stream.decode()
         }
 
@@ -80,10 +131,11 @@ pub(crate) mod flate {
             code_size: u8,
             output: Vec<u8>,
             eof: bool,
+            max_decoded: usize,
         }
 
         impl<'a> FlateStream<'a> {
-            fn new(data: &'a [u8]) -> Self {
+            fn new(data: &'a [u8], max_decoded: Option<usize>) -> Self {
                 FlateStream {
                     data,
                     pos: 0,
@@ -91,12 +143,21 @@ pub(crate) mod flate {
                     code_size: 0,
                     output: Vec::new(),
                     eof: false,
+                    max_decoded: max_decoded.unwrap_or(usize::MAX),
                 }
             }
 
             fn decode(&mut self) -> Option<Vec<u8>> {
                 while !self.eof && self.pos < self.data.len() {
                     self.read_block();
+
+                    // Bound the output against decompression bombs. `read_block`
+                    // appends at most one DEFLATE block, so the peak overshoot
+                    // past the limit is one block.
+                    if self.output.len() > self.max_decoded {
+                        debug!("flate stream exceeds the decoded-size limit");
+                        return None;
+                    }
                 }
 
                 Some(core::mem::take(&mut self.output))
@@ -570,10 +631,14 @@ pub(crate) mod lzw {
     use alloc::vec::Vec;
 
     /// Decode a LZW-encoded stream.
-    pub(crate) fn decode(data: &[u8], params: &Dict<'_>) -> Option<Vec<u8>> {
+    pub(crate) fn decode(
+        data: &[u8],
+        params: &Dict<'_>,
+        max_decoded: Option<usize>,
+    ) -> Option<Vec<u8>> {
         let params = PredictorParams::from_params(params);
 
-        let decoded = decode_impl(data, params.early_change)?;
+        let decoded = decode_impl(data, params.early_change, max_decoded)?;
 
         apply_predictor(decoded, &params)
     }
@@ -583,7 +648,8 @@ pub(crate) mod lzw {
     const MAX_ENTRIES: usize = 4096;
     const INITIAL_SIZE: u16 = 258;
 
-    fn decode_impl(data: &[u8], early_change: bool) -> Option<Vec<u8>> {
+    fn decode_impl(data: &[u8], early_change: bool, max_decoded: Option<usize>) -> Option<Vec<u8>> {
+        let max_decoded = max_decoded.unwrap_or(usize::MAX);
         let mut table = Table::new(early_change);
         let mut bit_size = table.code_length();
         let mut reader = BitReader::new(data);
@@ -591,6 +657,14 @@ pub(crate) mod lzw {
         let mut prev = None;
 
         loop {
+            // Bound the output against decompression bombs. Each iteration
+            // appends at most one table entry, so the peak overshoot past the
+            // limit is one entry.
+            if decoded.len() > max_decoded {
+                debug!("LZW stream exceeds the decoded-size limit");
+                return None;
+            }
+
             let next = match reader.read(bit_size) {
                 Some(code) => code as usize,
                 None => {
@@ -1033,7 +1107,7 @@ mod tests {
     #[test]
     fn decode_lzw() {
         let input = [0x80, 0x0B, 0x60, 0x50, 0x22, 0x0C, 0x0C, 0x85, 0x01];
-        let decoded = lzw::decode(&input, &Dict::default()).unwrap();
+        let decoded = lzw::decode(&input, &Dict::default(), None).unwrap();
 
         assert_eq!(decoded, vec![45, 45, 45, 45, 45, 65, 45, 45, 45, 66]);
     }
@@ -1044,7 +1118,7 @@ mod tests {
             0x78, 0x9c, 0xf3, 0x48, 0xcd, 0xc9, 0xc9, 0x7, 0x0, 0x5, 0x8c, 0x1, 0xf5,
         ];
 
-        let decoded = flate::decode(&input, &Dict::default()).unwrap();
+        let decoded = flate::decode(&input, &Dict::default(), None).unwrap();
         assert_eq!(decoded, b"Hello");
     }
 
@@ -1052,10 +1126,40 @@ mod tests {
     fn decode_flate() {
         let input = [0xf3, 0x48, 0xcd, 0xc9, 0xc9, 0x7, 0x0];
 
-        let decoded = flate::decode(&input, &Dict::default()).unwrap();
+        let decoded = flate::decode(&input, &Dict::default(), None).unwrap();
         assert_eq!(decoded, b"Hello");
     }
-    
+
+    /// `zlib.compress(&[0u8; 128 KiB])` — a 149-byte stream that inflates to
+    /// 128 KiB. Decoding it under a 64 KiB limit must return `None` rather
+    /// than inflating it. Because this is a genuine, valid zlib stream (it
+    /// decodes fine without a limit), a `None` result can only come from the
+    /// limit, never from a malformed input.
+    #[test]
+    fn flate_decode_rejects_decompression_bomb() {
+        const BOMB: &[u8] = &[
+            0x78, 0xda, 0xed, 0xc1, 0x31, 0x01, 0x00, 0x00, 0x00, 0xc2, 0xa0, 0xf5,
+            0x4f, 0xed, 0x61, 0x0d, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x6e, 0x00, 0x1e, 0x00, 0x01,
+        ];
+        assert_eq!(flate::decode(BOMB, &Dict::default(), Some(64 * 1024)), None);
+        assert_eq!(
+            flate::decode(BOMB, &Dict::default(), None).map(|d| d.len()),
+            Some(128 * 1024)
+        );
+    }
+
+
     fn predictor_expected() -> Vec<u8> {
         vec![
             // Row 1

--- a/hayro-syntax/src/filter/mod.rs
+++ b/hayro-syntax/src/filter/mod.rs
@@ -14,6 +14,7 @@ mod lzw_flate;
 mod png;
 mod run_length;
 
+use crate::limits::Limits;
 use crate::object::Dict;
 use crate::object::Name;
 use crate::object::dict::keys::*;
@@ -86,44 +87,46 @@ impl Filter {
         data: &[u8],
         params: &Dict<'_>,
         #[cfg_attr(not(feature = "images"), allow(unused))] image_params: &ImageDecodeParams,
+        #[cfg_attr(not(feature = "images"), allow(unused))] limits: Limits,
     ) -> Result<FilterResult<'static>, DecodeFailure> {
-        let res = match self {
-            Self::AsciiHexDecode => ascii_hex::decode(data)
-                .map(FilterResult::from_data)
-                .ok_or(DecodeFailure::StreamDecode),
-            Self::Ascii85Decode => ascii_85::decode(data)
-                .map(FilterResult::from_data)
-                .ok_or(DecodeFailure::StreamDecode),
-            Self::RunLengthDecode => run_length::decode(data)
-                .map(FilterResult::from_data)
-                .ok_or(DecodeFailure::StreamDecode),
-            Self::LzwDecode => lzw_flate::lzw::decode(data, params)
-                .map(FilterResult::from_data)
-                .ok_or(DecodeFailure::StreamDecode),
-            Self::FlateDecode => lzw_flate::flate::decode(data, params)
-                .map(FilterResult::from_data)
-                .ok_or(DecodeFailure::StreamDecode),
-            #[cfg(feature = "images")]
-            Self::DctDecode => {
-                dct::decode(data, params, image_params).ok_or(DecodeFailure::ImageDecode)
-            }
-            #[cfg(feature = "images")]
-            Self::CcittFaxDecode => {
-                ccitt::decode(data, params, image_params).ok_or(DecodeFailure::ImageDecode)
-            }
-            #[cfg(feature = "images")]
-            Self::Jbig2Decode => {
-                jbig2::decode(data, params, image_params).ok_or(DecodeFailure::ImageDecode)
-            }
-            #[cfg(feature = "images")]
-            Self::JpxDecode => jpx::decode(data, image_params).ok_or(DecodeFailure::ImageDecode),
-            #[cfg(not(feature = "images"))]
-            Self::DctDecode | Self::CcittFaxDecode | Self::Jbig2Decode | Self::JpxDecode => {
-                warn!("image decoding is not supported (enable the `images` feature)");
-                Err(DecodeFailure::ImageDecode)
-            }
-            _ => Err(DecodeFailure::StreamDecode),
-        };
+        let max_decoded = limits.max_decoded_stream_size.bound();
+        let res =
+            match self {
+                Self::AsciiHexDecode => ascii_hex::decode(data)
+                    .map(FilterResult::from_data)
+                    .ok_or(DecodeFailure::StreamDecode),
+                Self::Ascii85Decode => ascii_85::decode(data)
+                    .map(FilterResult::from_data)
+                    .ok_or(DecodeFailure::StreamDecode),
+                Self::RunLengthDecode => run_length::decode(data, max_decoded)
+                    .map(FilterResult::from_data)
+                    .ok_or(DecodeFailure::StreamDecode),
+                Self::LzwDecode => lzw_flate::lzw::decode(data, params, max_decoded)
+                    .map(FilterResult::from_data)
+                    .ok_or(DecodeFailure::StreamDecode),
+                Self::FlateDecode => lzw_flate::flate::decode(data, params, max_decoded)
+                    .map(FilterResult::from_data)
+                    .ok_or(DecodeFailure::StreamDecode),
+                #[cfg(feature = "images")]
+                Self::DctDecode => dct::decode(data, params, image_params, limits)
+                    .ok_or(DecodeFailure::ImageDecode),
+                #[cfg(feature = "images")]
+                Self::CcittFaxDecode => ccitt::decode(data, params, image_params, limits)
+                    .ok_or(DecodeFailure::ImageDecode),
+                #[cfg(feature = "images")]
+                Self::Jbig2Decode => jbig2::decode(data, params, image_params, limits)
+                    .ok_or(DecodeFailure::ImageDecode),
+                #[cfg(feature = "images")]
+                Self::JpxDecode => {
+                    jpx::decode(data, image_params, limits).ok_or(DecodeFailure::ImageDecode)
+                }
+                #[cfg(not(feature = "images"))]
+                Self::DctDecode | Self::CcittFaxDecode | Self::Jbig2Decode | Self::JpxDecode => {
+                    warn!("image decoding is not supported (enable the `images` feature)");
+                    Err(DecodeFailure::ImageDecode)
+                }
+                _ => Err(DecodeFailure::StreamDecode),
+            };
 
         if res.is_err() {
             warn!("failed to apply filter {}", self.debug_name());

--- a/hayro-syntax/src/filter/run_length.rs
+++ b/hayro-syntax/src/filter/run_length.rs
@@ -2,11 +2,20 @@ use crate::reader::Reader;
 use alloc::vec;
 use alloc::vec::Vec;
 
-pub(crate) fn decode(data: &[u8]) -> Option<Vec<u8>> {
+pub(crate) fn decode(data: &[u8], max_decoded: Option<usize>) -> Option<Vec<u8>> {
+    let max_decoded = max_decoded.unwrap_or(usize::MAX);
     let mut reader = Reader::new(data);
     let mut decoded = vec![];
 
     loop {
+        // Bound the output against expansion bombs: each 2-byte repeat pair
+        // can append up to 128 bytes, and `/Filter` arrays can chain layers.
+        // Checked once per iteration, so the peak overshoot is one run.
+        if decoded.len() > max_decoded {
+            debug!("run-length stream exceeds the decoded-size limit");
+            return None;
+        }
+
         let length = reader.read_byte()?;
 
         match length {
@@ -37,8 +46,26 @@ mod tests {
     fn run_length() {
         let input = vec![4, 10, 11, 12, 13, 14, 253, 3, 128];
         assert_eq!(
-            decode(&input).unwrap(),
+            decode(&input, None).unwrap(),
             vec![10, 11, 12, 13, 14, 3, 3, 3, 3]
         );
+    }
+
+    #[test]
+    fn run_length_rejects_expansion_bomb() {
+        const LIMIT: usize = 64 * 1024;
+
+        // Each [129, 0] pair expands to 128 zero bytes (257 - 129), so this
+        // ~1 KiB input expands past the limit and must be refused rather
+        // than ballooned. Without a limit it decodes fine, proving the
+        // rejection comes from the limit and not from a malformed stream.
+        let pairs = LIMIT / 128 + 2;
+        let mut input = Vec::with_capacity(pairs * 2 + 1);
+        for _ in 0..pairs {
+            input.extend_from_slice(&[129, 0]);
+        }
+        input.push(128); // EOD
+        assert_eq!(decode(&input, Some(LIMIT)), None);
+        assert!(decode(&input, None).is_some());
     }
 }

--- a/hayro-syntax/src/lib.rs
+++ b/hayro-syntax/src/lib.rs
@@ -87,6 +87,7 @@ pub(crate) mod sync;
 
 mod data;
 pub(crate) mod filter;
+mod limits;
 pub(crate) mod pdf;
 pub(crate) mod trivia;
 pub(crate) mod util;
@@ -110,4 +111,5 @@ pub mod reader;
 
 pub use data::PdfData;
 pub use filter::*;
+pub use limits::{Limit, Limits};
 pub use pdf::*;

--- a/hayro-syntax/src/limits.rs
+++ b/hayro-syntax/src/limits.rs
@@ -1,0 +1,152 @@
+//! Resource limits for parsing and decoding.
+
+/// An upper bound on a resource, or no bound at all.
+///
+/// Prefer this over `Option<T>` for a limit: the "no bound" case is the
+/// explicit [`Limit::Unlimited`], never an absent/`None` value that reads like
+/// "unset" but actually removes the guard. Only reach for [`Limit::Unlimited`]
+/// with trusted input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Limit<T> {
+    /// Reject anything exceeding this value.
+    AtMost(T),
+    /// Impose no limit.
+    Unlimited,
+}
+
+impl<T: Copy + Ord> Limit<T> {
+    /// Whether `value` is within this limit (always true when
+    /// [`Unlimited`](Limit::Unlimited)).
+    pub fn permits(self, value: T) -> bool {
+        match self {
+            Self::AtMost(max) => value <= max,
+            Self::Unlimited => true,
+        }
+    }
+
+    /// The bound as an `Option`: `Some(max)` when bounded, `None` when
+    /// [`Unlimited`](Limit::Unlimited).
+    pub fn bound(self) -> Option<T> {
+        match self {
+            Self::AtMost(max) => Some(max),
+            Self::Unlimited => None,
+        }
+    }
+}
+
+/// Resource limits applied while decoding the streams of a PDF file.
+///
+/// The limits are set when loading a document (see
+/// [`Pdf::new_with_options`](crate::Pdf::new_with_options)) and govern all
+/// processing of that document, including by consumers such as
+/// `hayro-interpret`. The defaults are generous but bounded, so a crafted
+/// file cannot force unbounded allocations while legitimate documents remain
+/// unaffected. Use [`Limits::no_limits`] to disable every check.
+///
+/// Enforcing a limit is a routine, expected outcome — a deliberately tight
+/// limit will skip large streams and images even on non-malicious files — so
+/// it is reported at `debug` level, not `warn`. An over-limit stream fails to
+/// decode; an over-limit image is skipped.
+///
+/// Note that streams parsed outside of a loaded document (for example while
+/// the cross-reference table itself is being built, or inline images inside
+/// content streams) are checked against [`Limits::DEFAULT`] rather than the
+/// configured values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Limits {
+    /// The maximum decompressed size of a single stream, in bytes.
+    ///
+    /// This bounds decompression bombs: chained `/Filter` arrays amplify
+    /// roughly 1000x per `FlateDecode`/`LZWDecode` layer (64x for
+    /// `RunLengthDecode`), so a tiny stream can otherwise expand to
+    /// gigabytes. A stream exceeding the limit is treated as a decode
+    /// failure.
+    pub max_decoded_stream_size: Limit<usize>,
+    /// The maximum width or height of an embedded image, in pixels.
+    ///
+    /// Enforced before any decode work; an image exceeding it is skipped.
+    pub max_image_dimension: Limit<u32>,
+    /// The maximum total number of pixels (width × height) of an embedded
+    /// image.
+    ///
+    /// This bounds decode-time allocations, which are proportional to the
+    /// claimed pixel count rather than the stream size. An image exceeding it
+    /// is skipped.
+    pub max_image_pixels: Limit<u64>,
+}
+
+impl Limits {
+    /// The default limits: 512 MiB per decoded stream, 65535 pixels per
+    /// image side and 500 million pixels per image.
+    pub const DEFAULT: Self = Self {
+        max_decoded_stream_size: Limit::AtMost(512 * 1024 * 1024),
+        max_image_dimension: Limit::AtMost(65535),
+        max_image_pixels: Limit::AtMost(500_000_000),
+    };
+
+    /// No limits at all: every check is disabled, restoring the unbounded
+    /// behavior of earlier versions. Only use this with trusted input.
+    pub const fn no_limits() -> Self {
+        Self {
+            max_decoded_stream_size: Limit::Unlimited,
+            max_image_dimension: Limit::Unlimited,
+            max_image_pixels: Limit::Unlimited,
+        }
+    }
+
+    /// Whether an image of the given dimensions is within the configured
+    /// limits.
+    ///
+    /// Returns `false` if either side exceeds
+    /// [`max_image_dimension`](Self::max_image_dimension) or the total pixel
+    /// count exceeds [`max_image_pixels`](Self::max_image_pixels). Decoders
+    /// call this with the *actual* dimensions they are about to allocate for —
+    /// which, for tiled or codestream-driven formats (JPEG 2000, CCITT,
+    /// JBIG2), come from the codec's own headers rather than the image
+    /// dictionary — so the limit bounds the allocation regardless of what the
+    /// dictionary claimed.
+    pub fn permits_image(&self, width: u32, height: u32) -> bool {
+        self.max_image_dimension.permits(width)
+            && self.max_image_dimension.permits(height)
+            && self
+                .max_image_pixels
+                .permits(u64::from(width) * u64::from(height))
+    }
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Limit, Limits};
+
+    #[test]
+    fn limit_permits_and_bound() {
+        assert!(Limit::AtMost(10u32).permits(10));
+        assert!(!Limit::AtMost(10u32).permits(11));
+        assert!(Limit::<u32>::Unlimited.permits(u32::MAX));
+
+        assert_eq!(Limit::AtMost(10u32).bound(), Some(10));
+        assert_eq!(Limit::<u32>::Unlimited.bound(), None);
+    }
+
+    #[test]
+    fn permits_image_bounds_both_axes() {
+        let limits = Limits {
+            max_image_dimension: Limit::AtMost(100),
+            max_image_pixels: Limit::AtMost(1000),
+            ..Limits::default()
+        };
+        assert!(limits.permits_image(20, 20)); // 400 px, within both
+        assert!(!limits.permits_image(101, 1)); // side exceeds dimension limit
+        assert!(!limits.permits_image(40, 40)); // 1600 px exceeds pixel limit
+
+        // Unlimited disables the check entirely.
+        assert!(Limits::no_limits().permits_image(u32::MAX, u32::MAX));
+    }
+}

--- a/hayro-syntax/src/object/stream.rs
+++ b/hayro-syntax/src/object/stream.rs
@@ -2,6 +2,7 @@
 
 use crate::crypto::DecryptionTarget;
 use crate::filter::Filter;
+use crate::limits::Limits;
 use crate::object;
 use crate::object::Dict;
 use crate::object::Name;
@@ -152,6 +153,15 @@ impl<'a> Stream<'a> {
         self.filters_and_params().filters
     }
 
+    /// Return the resource limits governing this stream.
+    ///
+    /// These are the limits configured when the containing document was
+    /// loaded (see [`Limits`]), or [`Limits::DEFAULT`] for streams parsed
+    /// outside of a loaded document.
+    pub fn limits(&self) -> Limits {
+        self.dict.ctx().xref().limits()
+    }
+
     /// Return the decoded data of the stream.
     ///
     /// Note that the result of this method will not be cached, so calling it multiple
@@ -169,6 +179,7 @@ impl<'a> Stream<'a> {
     ) -> Result<FilterResult<'a>, DecodeFailure> {
         let data = self.raw_data();
         let filters_and_params = self.filters_and_params();
+        let limits = self.limits();
 
         let mut current: Option<FilterResult<'a>> = None;
 
@@ -181,6 +192,7 @@ impl<'a> Stream<'a> {
                 current.as_ref().map(|c| c.data.as_ref()).unwrap_or(&data),
                 params,
                 image_params,
+                limits,
             )?;
             current = Some(new);
         }

--- a/hayro-syntax/src/pdf.rs
+++ b/hayro-syntax/src/pdf.rs
@@ -1,6 +1,7 @@
 //! The starting point for reading PDF files.
 
 use crate::PdfData;
+use crate::limits::Limits;
 use crate::object::Object;
 use crate::page::Pages;
 use crate::page::cached::CachedPages;
@@ -28,13 +29,23 @@ pub enum LoadPdfError {
     Invalid,
 }
 
+/// Options for loading a PDF file.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct PdfOptions<'a> {
+    /// The password to decrypt the document with, if any.
+    pub password: &'a str,
+    /// Resource limits applied while parsing and decoding the document.
+    pub limits: Limits,
+}
+
 #[allow(clippy::len_without_is_empty)]
 impl Pdf {
     /// Try to read the given PDF file.
     ///
     /// Returns `Err` if it was unable to read it.
     pub fn new(data: impl Into<PdfData>) -> Result<Self, LoadPdfError> {
-        Self::new_with_password(data, "")
+        Self::new_with_options(data, PdfOptions::default())
     }
 
     /// Try to read the given PDF file with a password.
@@ -44,14 +55,31 @@ impl Pdf {
         data: impl Into<PdfData>,
         password: &str,
     ) -> Result<Self, LoadPdfError> {
+        Self::new_with_options(
+            data,
+            PdfOptions {
+                password,
+                ..PdfOptions::default()
+            },
+        )
+    }
+
+    /// Try to read the given PDF file with the given options.
+    ///
+    /// Returns `Err` if it was unable to read it or if the password is incorrect.
+    pub fn new_with_options(
+        data: impl Into<PdfData>,
+        options: PdfOptions<'_>,
+    ) -> Result<Self, LoadPdfError> {
         let data = data.into();
-        let password = password.as_bytes();
+        let limits = options.limits;
+        let password = options.password.as_bytes();
         let version = find_version(data.as_ref()).unwrap_or(PdfVersion::Pdf10);
-        let xref = match root_xref(data.clone(), password) {
+        let xref = match root_xref(data.clone(), password, limits) {
             Ok(x) => x,
             Err(e) => match e {
                 XRefError::Unknown => {
-                    fallback(data.clone(), password).ok_or(LoadPdfError::Invalid)?
+                    fallback(data.clone(), password, limits).ok_or(LoadPdfError::Invalid)?
                 }
                 XRefError::Encryption(e) => return Err(LoadPdfError::Decryption(e)),
             },

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -2,6 +2,7 @@
 
 use crate::crypto::{DecryptionError, DecryptionTarget, Decryptor, get};
 use crate::data::Data;
+use crate::limits::Limits;
 use crate::metadata::Metadata;
 use crate::object::Name;
 use crate::object::ObjectIdentifier;
@@ -38,7 +39,7 @@ pub(crate) enum XRefError {
 }
 
 /// Parse the "root" xref from the PDF.
-pub(crate) fn root_xref(data: PdfData, password: &[u8]) -> Result<XRef, XRefError> {
+pub(crate) fn root_xref(data: PdfData, password: &[u8], limits: Limits) -> Result<XRef, XRefError> {
     let mut xref_map = FxHashMap::default();
     let xref_pos = find_last_xref_pos(data.as_ref()).ok_or(XRefError::Unknown)?;
     let trailer =
@@ -50,18 +51,19 @@ pub(crate) fn root_xref(data: PdfData, password: &[u8]) -> Result<XRef, XRefErro
         XRefInput::TrailerDictData(trailer),
         false,
         password,
+        limits,
     )
 }
 
 /// Try to manually parse the PDF to build an xref table and trailer dictionary.
-pub(crate) fn fallback(data: PdfData, password: &[u8]) -> Option<XRef> {
+pub(crate) fn fallback(data: PdfData, password: &[u8], limits: Limits) -> Option<XRef> {
     warn!("xref table was invalid, trying to manually build xref table");
-    let (xref_map, xref_input) = fallback_xref_map(&data, password);
+    let (xref_map, xref_input) = fallback_xref_map(&data, password, limits);
 
     if let Some(xref_input) = xref_input {
         warn!("rebuild xref table with {} entries", xref_map.len());
 
-        XRef::new(data.clone(), xref_map, xref_input, true, password).ok()
+        XRef::new(data.clone(), xref_map, xref_input, true, password, limits).ok()
     } else {
         warn!("couldn't find trailer dictionary, failed to rebuild xref table");
 
@@ -69,8 +71,12 @@ pub(crate) fn fallback(data: PdfData, password: &[u8]) -> Option<XRef> {
     }
 }
 
-fn fallback_xref_map<'a>(data: &'a PdfData, password: &[u8]) -> (XrefMap, Option<XRefInput<'a>>) {
-    fallback_xref_map_inner(data, ReaderContext::dummy(), true, password)
+fn fallback_xref_map<'a>(
+    data: &'a PdfData,
+    password: &[u8],
+    limits: Limits,
+) -> (XrefMap, Option<XRefInput<'a>>) {
+    fallback_xref_map_inner(data, ReaderContext::dummy(), true, password, limits)
 }
 
 fn fallback_xref_map_inner<'a>(
@@ -78,6 +84,7 @@ fn fallback_xref_map_inner<'a>(
     mut dummy_ctx: ReaderContext<'a>,
     recurse: bool,
     password: &[u8],
+    limits: Limits,
 ) -> (XrefMap, Option<XRefInput<'a>>) {
     let mut xref_map = FxHashMap::default();
     let mut trailer_dicts = vec![];
@@ -248,9 +255,10 @@ fn fallback_xref_map_inner<'a>(
             XRefInput::TrailerDictData(trailer_dict.as_ref().map(|d| d.data()).unwrap()),
             true,
             password,
+            limits,
         ) {
             let ctx = ReaderContext::new(&xref, false);
-            let (patched_map, _) = fallback_xref_map_inner(data, ctx, false, password);
+            let (patched_map, _) = fallback_xref_map_inner(data, ctx, false, password, limits);
             xref_map = patched_map;
         }
     }
@@ -274,12 +282,25 @@ const DUMMY_XREF: XRef = XRef(Inner::Dummy);
 pub struct XRef(Inner);
 
 impl XRef {
+    /// Return the resource limits configured for the document this xref
+    /// table belongs to.
+    ///
+    /// Dummy xref tables (used for objects parsed outside of a loaded
+    /// document) report [`Limits::DEFAULT`].
+    pub fn limits(&self) -> Limits {
+        match &self.0 {
+            Inner::Some(repr) => repr.limits,
+            Inner::Dummy => Limits::DEFAULT,
+        }
+    }
+
     fn new(
         data: PdfData,
         xref_map: XrefMap,
         input: XRefInput<'_>,
         repaired: bool,
         password: &[u8],
+        limits: Limits,
     ) -> Result<Self, XRefError> {
         // This is a bit hacky, but the problem is we can't read the resolved trailer dictionary
         // before we actually created the xref struct. So we first create it using dummy data
@@ -294,6 +315,7 @@ impl XRef {
             metadata: Arc::new(Metadata::default()),
             trailer_data,
             password: password.to_vec(),
+            limits,
         })));
 
         // We read the trailer twice, once to determine the encryption used and then a second
@@ -485,7 +507,7 @@ impl XRef {
         let mut locked = r.map.try_put().unwrap();
         assert!(!locked.repaired);
 
-        let (xref_map, _) = fallback_xref_map(r.data.get(), &r.password);
+        let (xref_map, _) = fallback_xref_map(r.data.get(), &r.password, r.limits);
         locked.xref_map = xref_map;
         locked.repaired = true;
     }
@@ -681,6 +703,7 @@ struct SomeRepr {
     has_ocgs: bool,
     password: Vec<u8>,
     trailer_data: TrailerData,
+    limits: Limits,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Follow-up to #1148, replacing the remaining pieces (stream decompression + image dimensions) with a configurable design rather than hardcoded constants — hopefully closer to the form you had in mind. The xref `/Prev` cycle and form-XObject recursion pieces shipped in your own 0.7 fixes, so they're dropped here.

## API

`Limits` (`#[non_exhaustive]`, every field optional so `None` disables that check):

- `max_decoded_stream_size` — default 512 MiB
- `max_image_dimension` — default 65535
- `max_image_pixels` — default 500M

`Limits::no_limits()` disables everything; `Limits::permits_image(w, h)` is the shared predicate. Set them via `Pdf::new_with_options(data, PdfOptions { password, limits })`; the existing `new` / `new_with_password` keep the defaults. The limits are stored in the xref table, so every stream of the document reaches them through its reader context — `Stream::limits()` exposes them to consumers, which is how hayro-interpret enforces the image checks without any signature changes. Streams parsed outside a loaded document (xref construction, inline images under dummy contexts) use `Limits::DEFAULT`.

**Open design question:** `PdfOptions` is a new public type. I chose an options struct over more constructors so that limits and password compose without a combinatorial `new_with_password_and_limits`, and so future options are non-breaking `#[non_exhaustive]` fields. If you'd rather not carry the struct, a single `Pdf::new_with_limits(data, limits)` works just as well — the enforcement underneath doesn't depend on how the entry point is spelled, so this is easy to reshape to your preference.

## Enforcement

**Decompression** — `max_decoded_stream_size` in every stream decode path: the flate2 path reads at most limit+1 bytes via `Read::take` and rejects on overflow; the pure-Rust flate fallback, LZW, and RunLength check their output length per iteration. Over-limit is a decode failure. Chained `/Filter` arrays amplify ~1000× per flate layer (64× for RunLength), so a few hundred bytes can otherwise expand to gigabytes, reachable from `Pdf::new`.

**Image dimensions** — checked via `Limits::permits_image` at the allocation sites. This matters beyond the image dictionary: for CCITT (`/Columns` × `/Rows` from the decode parameters), JBIG2, and JPEG 2000 (both from the codestream, which for JPEG 2000 may be tiled), the dimensions that size the buffer come from the codec, *independent of the `/Width` and `/Height` in the image dictionary* — so a dictionary check alone doesn't bound them. The checks live in `ImageXObject::new` (dictionary dims), in each of those filters (their real dims, before the allocation), and in `decode_context` against the final decoded dims (which size the sample buffers). JPEG is clamped down to the dictionary dims and checked there.

## Tests

A genuine 149-byte zlib bomb (inflates to 128 KiB), a RunLength expansion bomb, and an oversized CCITT stream are each rejected under a small explicit limit and decode fine with no limit — so a rejection can only come from the limit, never from a malformed stream.

Defaults are deliberately generous (they only bite adversarial input); happy to tune the values or reshape the API.
