### PR TITLE
hayro-interpret: Share the shading rasterization core between `hayro` and `hayro-svg`

### DIFF
--- a/hayro-interpret/src/encode.rs
+++ b/hayro-interpret/src/encode.rs
@@ -84,12 +84,9 @@ pub struct ShadingTexture {
 /// Exposed so that callers can bound the size of the resulting texture
 /// before sampling.
 pub fn texture_dimensions(bbox: Rect, scale: f32) -> (u32, u32) {
-    let base_width = (bbox.width() as f32).max(1.0);
-    let base_height = (bbox.height() as f32).max(1.0);
-
     (
-        (base_width * scale).ceil() as u32,
-        (base_height * scale).ceil() as u32,
+        (bbox.width() as f32 * scale).max(1.0).ceil() as u32,
+        (bbox.height() as f32 * scale).max(1.0).ceil() as u32,
     )
 }
 

--- a/hayro-interpret/src/encode.rs
+++ b/hayro-interpret/src/encode.rs
@@ -4,7 +4,8 @@ use crate::color::{AlphaColor, ColorComponents, ColorSpace};
 use crate::interpret::state::ActiveTransferFunction;
 use crate::pattern::ShadingPattern;
 use crate::shading::{ShadingFunction, ShadingType, Triangle};
-use kurbo::{Affine, Point};
+use crate::util::x_y_advances;
+use kurbo::{Affine, Point, Rect};
 use rustc_hash::FxHashMap;
 use smallvec::{ToSmallVec, smallvec};
 use std::sync::Arc;
@@ -38,7 +39,7 @@ pub enum EncodedShadingType {
 /// Encoded function-based shading.
 #[derive(Clone, Debug)]
 pub struct EncodedFunctionBasedShading {
-    pub(crate) domain: kurbo::Rect,
+    pub(crate) domain: Rect,
     pub(crate) function: ShadingFunction,
 }
 
@@ -62,6 +63,36 @@ pub struct EncodedSampledShading {
 #[derive(Clone, Debug)]
 pub struct EncodedDummyShading;
 
+/// A shading that was rasterized into a texture.
+pub struct ShadingTexture {
+    /// The straight (non-premultiplied) RGBA8 pixel data, row-major.
+    pub data: Vec<u8>,
+    /// The width of the texture in pixels.
+    pub width: u32,
+    /// The height of the texture in pixels.
+    pub height: u32,
+    /// The transform from texture space to the space of the rasterized
+    /// bounding box.
+    pub transform: Affine,
+    /// Whether any pixel of the texture is not fully opaque.
+    pub has_transparency: bool,
+}
+
+/// Return the texture dimensions [`EncodedShadingPattern::sample_texture`]
+/// uses for the given bounding box and scale factor.
+///
+/// Exposed so that callers can bound the size of the resulting texture
+/// before sampling.
+pub fn texture_dimensions(bbox: Rect, scale: f32) -> (u32, u32) {
+    let base_width = (bbox.width() as f32).max(1.0);
+    let base_height = (bbox.height() as f32).max(1.0);
+
+    (
+        (base_width * scale).ceil() as u32,
+        (base_height * scale).ceil() as u32,
+    )
+}
+
 impl EncodedShadingPattern {
     /// Sample the shading at the given position.
     #[inline]
@@ -79,6 +110,80 @@ impl EncodedShadingPattern {
                 components
             })
             .unwrap_or([0.0, 0.0, 0.0, 0.0])
+    }
+
+    /// Sample the shading on a pixel grid covering `bbox`, with `scale`
+    /// pixels per unit of `bbox`.
+    ///
+    /// The callback is invoked once per pixel in row-major order with the
+    /// straight (non-premultiplied) RGBA sample, letting callers apply their
+    /// own conversion. Returns the dimensions of the grid (see
+    /// [`texture_dimensions`]) and the transform from grid space to the space
+    /// of `bbox`. No size cap is applied — callers that need to bound the
+    /// texture size should check [`texture_dimensions`] first.
+    pub fn sample_texture(
+        &self,
+        bbox: Rect,
+        scale: f32,
+        mut f: impl FnMut([f32; 4]),
+    ) -> (u32, u32, Affine) {
+        let (width, height) = texture_dimensions(bbox, scale);
+        let inv_scale = 1.0 / scale as f64;
+
+        let (x_advance, y_advance) =
+            x_y_advances(&(Affine::scale(inv_scale) * self.base_transform));
+
+        let mut start_point = self.base_transform
+            * Affine::translate((0.5 * inv_scale, 0.5 * inv_scale))
+            * Point::new(bbox.x0, bbox.y0);
+
+        for _ in 0..height {
+            let mut point = start_point;
+
+            for _ in 0..width {
+                f(self.sample(point));
+
+                point += x_advance;
+            }
+
+            start_point += y_advance;
+        }
+
+        (
+            width,
+            height,
+            Affine::translate((bbox.x0, bbox.y0)) * Affine::scale(inv_scale),
+        )
+    }
+
+    /// Rasterize the shading into a straight (non-premultiplied) RGBA8
+    /// texture covering `bbox`, with `scale` pixels per unit of `bbox`.
+    ///
+    /// See [`sample_texture`](Self::sample_texture) for the grid semantics.
+    pub fn render_texture(&self, bbox: Rect, scale: f32) -> ShadingTexture {
+        let (width, height) = texture_dimensions(bbox, scale);
+        let mut data = Vec::with_capacity(width as usize * height as usize * 4);
+        let mut has_transparency = false;
+
+        let (_, _, transform) = self.sample_texture(bbox, scale, |sample| {
+            let converted = [
+                (sample[0] * 255.0 + 0.5) as u8,
+                (sample[1] * 255.0 + 0.5) as u8,
+                (sample[2] * 255.0 + 0.5) as u8,
+                (sample[3] * 255.0 + 0.5) as u8,
+            ];
+
+            has_transparency |= converted[3] != 255;
+            data.extend_from_slice(&converted);
+        });
+
+        ShadingTexture {
+            data,
+            width,
+            height,
+            transform,
+            has_transparency,
+        }
     }
 }
 
@@ -265,7 +370,7 @@ fn sample_triangles(
 }
 
 fn encode_function_shading(domain: &[f32; 4], function: &ShadingFunction) -> EncodedShadingType {
-    let domain = kurbo::Rect::new(
+    let domain = Rect::new(
         domain[0] as f64,
         domain[2] as f64,
         domain[1] as f64,

--- a/hayro-interpret/src/util.rs
+++ b/hayro-interpret/src/util.rs
@@ -181,3 +181,20 @@ impl RectExt for hayro_syntax::object::Rect {
         Rect::new(self.x0, self.y0, self.x1, self.y1)
     }
 }
+
+/// Return the vectors by which a point in the transformed space moves when
+/// advancing by one unit in the x or y direction, ignoring translation.
+pub fn x_y_advances(transform: &kurbo::Affine) -> (kurbo::Vec2, kurbo::Vec2) {
+    let scale_skew_transform = {
+        let c = transform.as_coeffs();
+        kurbo::Affine::new([c[0], c[1], c[2], c[3], 0.0, 0.0])
+    };
+
+    let x_advance = scale_skew_transform * kurbo::Point::new(1.0, 0.0);
+    let y_advance = scale_skew_transform * kurbo::Point::new(0.0, 1.0);
+
+    (
+        kurbo::Vec2::new(x_advance.x, x_advance.y),
+        kurbo::Vec2::new(y_advance.x, y_advance.y),
+    )
+}

--- a/hayro-svg/src/paint.rs
+++ b/hayro-svg/src/paint.rs
@@ -1,12 +1,12 @@
 use crate::clip::CachedClipPath;
 use crate::{Id, hash128};
 use crate::{SvgRenderer, convert_transform};
-use hayro_interpret::encode::{EncodedShadingPattern, EncodedShadingType};
+use hayro_interpret::encode::EncodedShadingType;
 use hayro_interpret::gradient::{SvgGradient, SvgGradientKind};
 use hayro_interpret::pattern::{Pattern, ShadingPattern, TilingPattern};
 use hayro_interpret::{CacheKey, FillRule, Paint, StrokeProps};
 use image::{DynamicImage, ImageBuffer};
-use kurbo::{Affine, Point, Rect, Shape, Vec2};
+use kurbo::{Affine, Rect, Shape};
 
 #[derive(Clone)]
 pub(crate) struct CachedTilingPattern<'a> {
@@ -331,8 +331,11 @@ impl<'a> SvgRenderer<'a> {
 
         for (id, shading) in shadings.iter() {
             let encoded = shading.pattern.encode();
-            let (image, transform) = render_shading_texture(shading.bbox, &encoded);
-            self.write_image(&image, true, Some(id), transform);
+            let texture = encoded.render_texture(shading.bbox, 1.0);
+            let image = DynamicImage::ImageRgba8(
+                ImageBuffer::from_raw(texture.width, texture.height, texture.data).unwrap(),
+            );
+            self.write_image(&image, true, Some(id), texture.transform);
         }
 
         self.xml.end_element();
@@ -447,68 +450,4 @@ fn write_gradient(xml: &mut xmlwriter::XmlWriter, id: &str, gradient: &SvgGradie
     }
 
     xml.end_element();
-}
-
-fn render_shading_texture(
-    bbox: Rect,
-    shading_pattern: &EncodedShadingPattern,
-) -> (DynamicImage, Affine) {
-    const SCALE: f32 = 1.0;
-    const INV_SCALE: f32 = 1.0 / SCALE;
-
-    let base_width = (bbox.width() as f32).max(1.0);
-    let base_height = (bbox.height() as f32).max(1.0);
-
-    let width = (base_width * SCALE).ceil() as u32;
-    let height = (base_height * SCALE).ceil() as u32;
-
-    let (x_advance, y_advance) =
-        x_y_advances(&(Affine::scale(INV_SCALE as f64) * shading_pattern.base_transform));
-
-    let mut buf = vec![0_u8; width as usize * height as usize * 4];
-    let mut start_point = shading_pattern.base_transform
-        * Affine::translate((0.5, 0.5))
-        * Point::new(bbox.x0, bbox.y0);
-
-    for row in buf.chunks_exact_mut(width as usize * 4) {
-        let mut point = start_point;
-
-        for pixel in row.chunks_exact_mut(4) {
-            let sample = shading_pattern.sample(point);
-            let converted = [
-                (sample[0] * 255.0 + 0.5) as u8,
-                (sample[1] * 255.0 + 0.5) as u8,
-                (sample[2] * 255.0 + 0.5) as u8,
-                (sample[3] * 255.0 + 0.5) as u8,
-            ];
-
-            pixel.copy_from_slice(&converted);
-
-            point += x_advance;
-        }
-
-        start_point += y_advance;
-    }
-
-    let image = DynamicImage::ImageRgba8(ImageBuffer::from_raw(width, height, buf).unwrap());
-
-    (
-        image,
-        Affine::translate((bbox.x0, bbox.y0)) * Affine::scale(INV_SCALE as f64),
-    )
-}
-
-fn x_y_advances(transform: &Affine) -> (Vec2, Vec2) {
-    let scale_skew_transform = {
-        let c = transform.as_coeffs();
-        Affine::new([c[0], c[1], c[2], c[3], 0.0, 0.0])
-    };
-
-    let x_advance = scale_skew_transform * Point::new(1.0, 0.0);
-    let y_advance = scale_skew_transform * Point::new(0.0, 1.0);
-
-    (
-        Vec2::new(x_advance.x, x_advance.y),
-        Vec2::new(y_advance.x, y_advance.y),
-    )
 }

--- a/hayro/src/image.rs
+++ b/hayro/src/image.rs
@@ -1,5 +1,6 @@
-use crate::{Renderer, x_y_advances};
+use crate::Renderer;
 use fearless_simd::{Level, Select, Simd, SimdBase, SimdInto, mask8x32, u8x32, u16x32};
+use hayro_interpret::util::x_y_advances;
 use hayro_interpret::{FillRule, ImageData, ImageDrawProps, LumaData, Paint, RgbData};
 use kurbo::{Affine, Point, Rect};
 use pic_scale::{

--- a/hayro/src/lib.rs
+++ b/hayro/src/lib.rs
@@ -44,7 +44,7 @@ use hayro_interpret::hayro_syntax::page::Page;
 use hayro_interpret::util::{RectExt, TransformExt};
 use hayro_interpret::{BlendMode, Context, DrawMode, DrawProps, ImageDrawProps, SoftMask};
 use hayro_interpret::{ClipPath, interpret_page};
-use kurbo::{Affine, BezPath, Point, Rect, Shape, Vec2};
+use kurbo::{Affine, BezPath, Rect, Shape};
 use pic_scale::Scaler;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
@@ -334,21 +334,6 @@ pub(crate) fn derive_settings(settings: &vello_cpu::RenderSettings) -> vello_cpu
         num_threads: 0,
         ..*settings
     }
-}
-
-pub(crate) fn x_y_advances(transform: &Affine) -> (Vec2, Vec2) {
-    let scale_skew_transform = {
-        let c = transform.as_coeffs();
-        Affine::new([c[0], c[1], c[2], c[3], 0.0, 0.0])
-    };
-
-    let x_advance = scale_skew_transform * Point::new(1.0, 0.0);
-    let y_advance = scale_skew_transform * Point::new(0.0, 1.0);
-
-    (
-        Vec2::new(x_advance.x, x_advance.y),
-        Vec2::new(y_advance.x, y_advance.y),
-    )
 }
 
 fn convert_fill_rule(fill_rule: FillRule) -> Fill {

--- a/hayro/src/paint.rs
+++ b/hayro/src/paint.rs
@@ -1,11 +1,12 @@
-use crate::{Renderer, x_y_advances};
+use crate::Renderer;
 use hayro_interpret::Paint;
-use hayro_interpret::encode::{EncodedShadingPattern, EncodedShadingType};
+use hayro_interpret::encode::{EncodedShadingType, texture_dimensions};
 use hayro_interpret::gradient::SvgGradientKind;
 use hayro_interpret::pattern::Pattern;
-use kurbo::{Affine, BezPath, Point, Rect, Shape};
+use hayro_interpret::util::x_y_advances;
+use kurbo::{Affine, BezPath, Rect, Shape};
 use std::sync::Arc;
-use vello_cpu::color::{AlphaColor, DynamicColor, PremulRgba8, Srgb};
+use vello_cpu::color::{AlphaColor, DynamicColor, Srgb};
 use vello_cpu::peniko::{ColorStop, Gradient, ImageQuality, ImageSampler};
 use vello_cpu::{Image, ImageSource, PaintType, Pixmap, peniko};
 
@@ -90,8 +91,16 @@ impl Renderer<'_> {
 
                             PaintType::Gradient(gradient)
                         } else {
-                            let (image, width, height, transform, may_have_transparency) =
-                                render_shading_texture(bbox, &encoded);
+                            let (width, height) = texture_dimensions(bbox, 1.0);
+                            let mut image = Vec::with_capacity(width as usize * height as usize);
+                            let mut may_have_transparency = false;
+                            let (width, height, transform) =
+                                encoded.sample_texture(bbox, 1.0, |sample| {
+                                    let pixel =
+                                        AlphaColor::<Srgb>::new(sample).premultiply().to_rgba8();
+                                    may_have_transparency |= pixel.a != 255;
+                                    image.push(pixel);
+                                });
                             paint_transform = path_transform.inverse() * transform;
 
                             let pixmap = Pixmap::from_parts_with_opacity(
@@ -186,46 +195,4 @@ impl Renderer<'_> {
 
         clip_path
     }
-}
-
-// TODO: Deduplicate with hayro-svg?
-fn render_shading_texture(
-    path_bbox: Rect,
-    shading_pattern: &EncodedShadingPattern,
-) -> (Vec<PremulRgba8>, u32, u32, Affine, bool) {
-    let base_width = (path_bbox.width() as f32).max(1.0);
-    let base_height = (path_bbox.height() as f32).max(1.0);
-
-    let width = (base_width).ceil() as u32;
-    let height = (base_height).ceil() as u32;
-
-    let (x_advance, y_advance) = x_y_advances(&shading_pattern.base_transform);
-
-    let mut buf = vec![PremulRgba8::from_u32(0); width as usize * height as usize];
-    let mut start_point = shading_pattern.base_transform
-        * Affine::translate((0.5, 0.5))
-        * Point::new(path_bbox.x0, path_bbox.y0);
-    let mut may_have_transparency = false;
-
-    for row in buf.chunks_exact_mut(width as usize) {
-        let mut point = start_point;
-
-        for pixel in row {
-            let sample = shading_pattern.sample(point);
-            *pixel = AlphaColor::<Srgb>::new(sample).premultiply().to_rgba8();
-            may_have_transparency |= pixel.a != 255;
-
-            point += x_advance;
-        }
-
-        start_point += y_advance;
-    }
-
-    (
-        buf,
-        width,
-        height,
-        Affine::translate((path_bbox.x0, path_bbox.y0)),
-        may_have_transparency,
-    )
 }


### PR DESCRIPTION
Resolves the `// TODO: Deduplicate with hayro-svg?` in hayro's paint code: both crates carry a private `render_shading_texture` with the same loop shape. This adds `EncodedShadingPattern::sample_texture`, which drives the shared placement/iteration logic but hands each pixel to a caller closure — so each consumer keeps its own quantization and the ports are bit-identical by construction — plus a `render_texture` convenience returning straight RGBA8 (`x_y_advances` becomes `pub` to support it). Both existing copies now delegate to the shared core, which is scale-parameterized (pixel centers at `0.5/scale`), so external consumers can also rasterize at other resolutions. No behavior change; the existing shading ref tests pass unchanged.