### PR TITLE
Expose vello_cpu multithreading through RenderSettings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1219,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-channel"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95be4d57809897b5a7539fc15a7dfe0e84141bc3dfaa2e9b1b27caa90acf61ab"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "pdf-writer"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,9 +1492,9 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1840,6 +1858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,9 +2085,13 @@ version = "0.0.9"
 source = "git+https://github.com/linebender/vello?rev=dc23e93841d20060743e490ef49c1e0d0d22cf40#dc23e93841d20060743e490ef49c1e0d0d22cf40"
 dependencies = [
  "bytemuck",
+ "crossbeam-channel",
  "glifo",
  "hashbrown",
+ "ordered-channel",
  "png 0.18.1",
+ "rayon",
+ "thread_local",
  "vello_common",
 ]
 

--- a/hayro/Cargo.toml
+++ b/hayro/Cargo.toml
@@ -28,6 +28,9 @@ embed-fonts = ["hayro-interpret/embed-fonts"]
 # Embed the 61 predefined cmaps into the binary. Adds about ~250KB of brotli-encoded data.
 embed-cmaps = ["hayro-interpret/embed-cmaps"]
 logging = ["hayro-interpret/logging"]
+# Enable multi-threaded rendering in vello_cpu, allowing `RenderSettings::num_threads`
+# to take effect.
+multithreading = ["vello_cpu/multithreading"]
 # Enable SIMD-accelerated image resizing in pic-scale.
 simd = ["pic-scale/neon", "pic-scale/rdm", "pic-scale/sse", "pic-scale/avx"]
 

--- a/hayro/README.md
+++ b/hayro/README.md
@@ -32,8 +32,10 @@ For usage examples, see the [example](https://github.com/LaurenzV/hayro/tree/mas
 the GitHub repository.
 
 ### Cargo features
-This crate has one optional feature:
+This crate has the following optional features:
 - `embed-fonts`: See the description of [`hayro-interpret`](https://docs.rs/hayro-interpret/latest/hayro_interpret/#cargo-features) for more information.
+- `multithreading`: Enable support for multi-threaded rendering. See
+  [`RenderSettings::num_threads`](https://docs.rs/hayro/latest/hayro/struct.RenderSettings.html#structfield.num_threads) for more information.
 
 <!-- cargo-rdme end -->
 

--- a/hayro/src/lib.rs
+++ b/hayro/src/lib.rs
@@ -26,8 +26,10 @@ For usage examples, see the [example](https://github.com/LaurenzV/hayro/tree/mas
 the GitHub repository.
 
 ## Cargo features
-This crate has one optional feature:
+This crate has the following optional features:
 - `embed-fonts`: See the description of [`hayro-interpret`](https://docs.rs/hayro-interpret/latest/hayro_interpret/#cargo-features) for more information.
+- `multithreading`: Enable support for multi-threaded rendering. See
+  [`RenderSettings::num_threads`] for more information.
 */
 
 #![forbid(unsafe_code)]
@@ -218,6 +220,12 @@ pub struct RenderSettings {
     /// The background color. Determines the color of the base
     /// rectangle during rendering to a pixmap.
     pub bg_color: AlphaColor<Srgb>,
+    /// The number of worker threads to use for rendering. If set to 0 (the default),
+    /// rendering happens synchronously on the current thread.
+    ///
+    /// Only has an effect if the `multithreading` feature is enabled. Note that nested
+    /// content (like soft masks and tiling patterns) is always rendered single-threaded.
+    pub num_threads: u16,
 }
 
 impl Default for RenderSettings {
@@ -228,6 +236,7 @@ impl Default for RenderSettings {
             width: None,
             height: None,
             bg_color: TRANSPARENT,
+            num_threads: 0,
         }
     }
 }
@@ -261,7 +270,7 @@ pub fn render<'a>(
 
     let vc_settings = vello_cpu::RenderSettings {
         level: vello_cpu::Level::new(),
-        num_threads: 0,
+        num_threads: render_settings.num_threads,
     };
 
     let global = GlobalState::new(cache);
@@ -287,6 +296,8 @@ pub fn render<'a>(
 
     let mut pixmap = Pixmap::new(pix_width, pix_height);
     let mut resources = vello_cpu::Resources::default();
+    // Required when rendering multi-threaded, and a no-op otherwise.
+    device.ctx.flush();
     device.ctx.render(&mut pixmap, &mut resources);
 
     pixmap
@@ -329,6 +340,10 @@ pub fn render_pdf(
     Some(rendered)
 }
 
+/// Derive the settings for nested render contexts (used for soft masks, stencil masks
+/// and tiling patterns). Those always render single-threaded: they are created on the
+/// fly while interpreting the page, so spawning a worker pool for each of them would
+/// cost more than it gains.
 pub(crate) fn derive_settings(settings: &vello_cpu::RenderSettings) -> vello_cpu::RenderSettings {
     vello_cpu::RenderSettings {
         num_threads: 0,


### PR DESCRIPTION
Closes #1316.

## What

`hayro::render` hardcoded `num_threads: 0` when building the top-level `vello_cpu::RenderSettings`, so embedders had no way to opt into vello_cpu's multithreaded rendering. For large raster targets, single-threaded fills dominate wall time.

This adds a `num_threads` field to `hayro::RenderSettings` (default `0`, preserving current behavior) that is threaded through to the top-level `RenderContext`. A new `multithreading` feature (disabled by default) forwards to `vello_cpu/multithreading`, so the extra dependencies (rayon, crossbeam, ...) are only pulled in by users who opt in.

`device.ctx.flush()` is now called before rasterizing the top-level context — required in multi-threaded mode, a no-op otherwise.

## Why nested contexts stay single-threaded

Soft masks, stencil masks, and tiling patterns each get their own nested `RenderContext`, created on the fly while interpreting the page. `derive_settings` keeps forcing `num_threads: 0` for those: spawning a worker pool per nested context (potentially many per page) would cost more than it gains. Only the top-level, page-sized context benefits from multithreading.

## Verification

- `cargo hack check --each-feature -p hayro` — all 8 combinations pass, including `multithreading`
- `cargo clippy --workspace --exclude hayro-demo --exclude hayro-bench --tests --examples -- -D warnings` and `cargo fmt --check` clean on Rust 1.92 (the version pinned in this repo's CI)
- Rendered a corpus of 6 PDFs / 147 pages with `num_threads: 0` vs a non-zero value (multithreading feature enabled): pixel-identical output
- Existing load/doc tests pass unmodified