### PR TITLE
hayro: Optimize performance of images with differently-sized masks

### DIFF
--- a/hayro/src/image.rs
+++ b/hayro/src/image.rs
@@ -6,7 +6,7 @@ use pic_scale::{
     ImageSize, ImageStore, ImageStoreMut, PicScaleError, Resampling, ResamplingFunction, Scaler,
 };
 use std::sync::Arc;
-use vello_cpu::peniko::{Fill, ImageQuality, ImageSampler};
+use vello_cpu::peniko::{Compose, Fill, ImageQuality, ImageSampler, Mix};
 use vello_cpu::{Image, ImageSource, Mask, Pixmap, peniko};
 
 // Previously, we used `CatmullRom`. The problem with that one is that it
@@ -80,130 +80,38 @@ impl RenderImageData {
 }
 
 impl Renderer<'_> {
-    /// Draw an image whose alpha mask has different dimensions or a different
-    /// interpolation setting than the image itself (`/SMask` and stencil `/Mask`
-    /// streams have their own dimensions).
-    ///
-    /// The alpha channel is resampled onto a common pixel grid and attached
-    /// directly to the image, so that the combined image can be drawn in a
-    /// single pass. Compared to routing the mask through a nested render
-    /// context, this avoids materializing several intermediate buffers at mask
-    /// resolution and drawing the image content twice (see issue #1315).
     fn draw_image_with_alpha_mask(&mut self, image_data: RenderImageData, alpha_data: LumaData) {
         let img_width = image_data.width();
         let img_height = image_data.height();
-        let interpolate = image_data.interpolate();
-
-        // In most cases, the image's own dimensions serve as the common grid.
-        // However, if the mask stores more detail than the image on some axis
-        // (common for stencil masks of scanned pages), keep as much of that
-        // detail as remains visible at the current scale by extending the grid
-        // up to the image's on-screen footprint.
-        let (grid_width, grid_height) = {
-            let (x_scale, y_scale) = {
-                let (x, y) = x_y_advances(self.ctx.transform());
-                (x.length() as f32, y.length() as f32)
-            };
-            let max_dim = (u16::MAX / 2) as u32;
-            let screen_width = ((img_width as f32 * x_scale) as u32).clamp(1, max_dim);
-            let screen_height = ((img_height as f32 * y_scale) as u32).clamp(1, max_dim);
-
-            (
-                img_width.max(screen_width.min(alpha_data.width)),
-                img_height.max(screen_height.min(alpha_data.height)),
-            )
-        };
-
-        // Match the image's interpolation setting so that the call to
-        // `draw_image` below doesn't dispatch back to this method.
-        let alpha_data = if (alpha_data.width, alpha_data.height) == (grid_width, grid_height) {
-            LumaData {
-                interpolate,
-                ..alpha_data
-            }
-        } else {
-            let scale_factors = alpha_data.scale_factors;
-            let data = self.resize_image_data(
-                alpha_data.data,
-                alpha_data.width,
-                alpha_data.height,
-                grid_width,
-                grid_height,
-                ImagePixelFormat::Luma,
+        let image_transform = *self.ctx.transform();
+        let mask_transform = image_transform
+            * Affine::scale_non_uniform(
+                img_width as f64 / alpha_data.width as f64,
+                img_height as f64 / alpha_data.height as f64,
             );
-
-            LumaData {
-                data,
-                width: grid_width,
-                height: grid_height,
-                interpolate,
-                scale_factors,
-            }
+        let mask_image = SolidColorImage {
+            color: [0; 3],
+            width: alpha_data.width,
+            height: alpha_data.height,
+            interpolate: alpha_data.interpolate,
         };
 
-        let image_data = if (img_width, img_height) == (grid_width, grid_height) {
-            image_data
-        } else {
-            // The mask is more detailed than the image, so the image is drawn
-            // at the mask-derived grid resolution instead. `draw_image`
-            // positions the image based on its pixel dimensions, so compensate
-            // for the dimension change in the transform.
-            self.ctx.set_transform(
-                *self.ctx.transform()
-                    * Affine::scale_non_uniform(
-                        img_width as f64 / grid_width as f64,
-                        img_height as f64 / grid_height as f64,
-                    ),
-            );
+        self.ctx.push_layer(None, None, None, None, None);
+        self.ctx.set_transform(image_transform);
+        self.draw_image(image_data, None);
 
-            match image_data {
-                RenderImageData::Rgb(rgb) => {
-                    let scale_factors = rgb.scale_factors;
-                    let data = self.resize_image_data(
-                        rgb.data,
-                        img_width,
-                        img_height,
-                        grid_width,
-                        grid_height,
-                        ImagePixelFormat::Rgb,
-                    );
-
-                    RenderImageData::Rgb(RgbData {
-                        data,
-                        width: grid_width,
-                        height: grid_height,
-                        interpolate,
-                        scale_factors,
-                    })
-                }
-                RenderImageData::Luma(luma) => {
-                    let scale_factors = luma.scale_factors;
-                    let data = self.resize_image_data(
-                        luma.data,
-                        img_width,
-                        img_height,
-                        grid_width,
-                        grid_height,
-                        ImagePixelFormat::Luma,
-                    );
-
-                    RenderImageData::Luma(LumaData {
-                        data,
-                        width: grid_width,
-                        height: grid_height,
-                        interpolate,
-                        scale_factors,
-                    })
-                }
-                RenderImageData::Solid(solid) => RenderImageData::Solid(SolidColorImage {
-                    width: grid_width,
-                    height: grid_height,
-                    ..solid
-                }),
-            }
-        };
-
-        self.draw_image(image_data, Some(alpha_data));
+        self.ctx.push_layer(
+            None,
+            Some(peniko::BlendMode::new(Mix::Normal, Compose::DestIn)),
+            None,
+            None,
+            None,
+        );
+        self.ctx.set_transform(mask_transform);
+        self.draw_image(RenderImageData::Solid(mask_image), Some(alpha_data));
+        self.ctx.pop_layer();
+        self.ctx.pop_layer();
+        self.ctx.set_transform(image_transform);
     }
 
     fn resize_image_data(

--- a/hayro/src/image.rs
+++ b/hayro/src/image.rs
@@ -80,36 +80,130 @@ impl RenderImageData {
 }
 
 impl Renderer<'_> {
+    /// Draw an image whose alpha mask has different dimensions or a different
+    /// interpolation setting than the image itself (`/SMask` and stencil `/Mask`
+    /// streams have their own dimensions).
+    ///
+    /// The alpha channel is resampled onto a common pixel grid and attached
+    /// directly to the image, so that the combined image can be drawn in a
+    /// single pass. Compared to routing the mask through a nested render
+    /// context, this avoids materializing several intermediate buffers at mask
+    /// resolution and drawing the image content twice (see issue #1315).
     fn draw_image_with_alpha_mask(&mut self, image_data: RenderImageData, alpha_data: LumaData) {
-        let mask = {
-            let transform = *self.ctx.transform()
-                * Affine::scale_non_uniform(
-                    image_data.width() as f64 / alpha_data.width as f64,
-                    image_data.height() as f64 / alpha_data.height as f64,
-                );
-            let mut renderer = self.child(self.ctx.width(), self.ctx.height());
-            let mut mask_pix = Pixmap::new(self.ctx.width(), self.ctx.height());
-            let rgb_data = ImageData::Rgb(RgbData {
-                data: vec![0; alpha_data.width as usize * alpha_data.height as usize * 3],
-                width: alpha_data.width,
-                height: alpha_data.height,
-                interpolate: alpha_data.interpolate,
-                scale_factors: alpha_data.scale_factors,
-            });
-            renderer.ctx.set_transform(transform);
-            // Note that there is a circle between `draw_image` and `draw_image_with_alpha_mask`,
-            // but `draw_image_with_alpha_mask` is only called if the dimensions or interpolate
-            // values between alpha_data and rgb_data don't match, which they do here.
-            renderer.draw_image(rgb_data, Some(alpha_data));
-            renderer.ctx.flush();
-            let mut resources = vello_cpu::Resources::default();
-            renderer.ctx.render(&mut mask_pix, &mut resources);
-            Mask::new_alpha(&mask_pix)
+        let img_width = image_data.width();
+        let img_height = image_data.height();
+        let interpolate = image_data.interpolate();
+
+        // In most cases, the image's own dimensions serve as the common grid.
+        // However, if the mask stores more detail than the image on some axis
+        // (common for stencil masks of scanned pages), keep as much of that
+        // detail as remains visible at the current scale by extending the grid
+        // up to the image's on-screen footprint.
+        let (grid_width, grid_height) = {
+            let (x_scale, y_scale) = {
+                let (x, y) = x_y_advances(self.ctx.transform());
+                (x.length() as f32, y.length() as f32)
+            };
+            let max_dim = (u16::MAX / 2) as u32;
+            let screen_width = ((img_width as f32 * x_scale) as u32).clamp(1, max_dim);
+            let screen_height = ((img_height as f32 * y_scale) as u32).clamp(1, max_dim);
+
+            (
+                img_width.max(screen_width.min(alpha_data.width)),
+                img_height.max(screen_height.min(alpha_data.height)),
+            )
         };
 
-        self.ctx.push_mask_layer(mask);
-        self.draw_image(image_data, None);
-        self.ctx.pop_layer();
+        // Match the image's interpolation setting so that the call to
+        // `draw_image` below doesn't dispatch back to this method.
+        let alpha_data = if (alpha_data.width, alpha_data.height) == (grid_width, grid_height) {
+            LumaData {
+                interpolate,
+                ..alpha_data
+            }
+        } else {
+            let scale_factors = alpha_data.scale_factors;
+            let data = self.resize_image_data(
+                alpha_data.data,
+                alpha_data.width,
+                alpha_data.height,
+                grid_width,
+                grid_height,
+                ImagePixelFormat::Luma,
+            );
+
+            LumaData {
+                data,
+                width: grid_width,
+                height: grid_height,
+                interpolate,
+                scale_factors,
+            }
+        };
+
+        let image_data = if (img_width, img_height) == (grid_width, grid_height) {
+            image_data
+        } else {
+            // The mask is more detailed than the image, so the image is drawn
+            // at the mask-derived grid resolution instead. `draw_image`
+            // positions the image based on its pixel dimensions, so compensate
+            // for the dimension change in the transform.
+            self.ctx.set_transform(
+                *self.ctx.transform()
+                    * Affine::scale_non_uniform(
+                        img_width as f64 / grid_width as f64,
+                        img_height as f64 / grid_height as f64,
+                    ),
+            );
+
+            match image_data {
+                RenderImageData::Rgb(rgb) => {
+                    let scale_factors = rgb.scale_factors;
+                    let data = self.resize_image_data(
+                        rgb.data,
+                        img_width,
+                        img_height,
+                        grid_width,
+                        grid_height,
+                        ImagePixelFormat::Rgb,
+                    );
+
+                    RenderImageData::Rgb(RgbData {
+                        data,
+                        width: grid_width,
+                        height: grid_height,
+                        interpolate,
+                        scale_factors,
+                    })
+                }
+                RenderImageData::Luma(luma) => {
+                    let scale_factors = luma.scale_factors;
+                    let data = self.resize_image_data(
+                        luma.data,
+                        img_width,
+                        img_height,
+                        grid_width,
+                        grid_height,
+                        ImagePixelFormat::Luma,
+                    );
+
+                    RenderImageData::Luma(LumaData {
+                        data,
+                        width: grid_width,
+                        height: grid_height,
+                        interpolate,
+                        scale_factors,
+                    })
+                }
+                RenderImageData::Solid(solid) => RenderImageData::Solid(SolidColorImage {
+                    width: grid_width,
+                    height: grid_height,
+                    ..solid
+                }),
+            }
+        };
+
+        self.draw_image(image_data, Some(alpha_data));
     }
 
     fn resize_image_data(

--- a/hayro/src/image.rs
+++ b/hayro/src/image.rs
@@ -108,6 +108,10 @@ impl Renderer<'_> {
             None,
         );
         self.ctx.set_transform(mask_transform);
+        // Note that there is a circle between `draw_image` and `draw_image_with_alpha_mask`,
+        // but `draw_image_with_alpha_mask` is only called if the dimensions or interpolate
+        // values between alpha_data and rgb_data don't match. Here we use a
+        // `SolidColorImage` so it doesn't affect it.
         self.draw_image(RenderImageData::Solid(mask_image), Some(alpha_data));
         self.ctx.pop_layer();
         self.ctx.pop_layer();


### PR DESCRIPTION
Closes #1315.

## What

When an image's `/SMask` or stencil `/Mask` has different dimensions (or a different `/Interpolate` flag) than the image itself, `draw_image_with_alpha_mask` previously:

1. materialized a zeroed RGB carrier buffer at *mask* resolution (7 MB for the file in #1315), purely so the alpha could be routed through `draw_image`,
2. rendered that carrier into a nested full-canvas `RenderContext`,
3. converted the resulting pixmap into a full-canvas `Mask`, and
4. drew the actual image a second time below a `push_mask_layer`.

This PR replaces the detour with a direct composition: the alpha channel is resampled onto a common pixel grid (via the existing single-channel `pic-scale` path) and attached as the image's alpha, so the combined image is drawn in a single pass — no carrier buffer, no nested render, no double draw, no mask layer.

**Grid selection:** normally the image's own dimensions. If the mask stores more detail than the image on some axis (common for stencil masks of scanned pages, like the 450x588 JPEG + 1350x1763 JBIG2 mask in #1315), the grid is extended up to the image's on-screen footprint, so mask detail that would actually be visible is not thrown away. In that case the image is resampled to the grid too and the transform is compensated.

## Measurements

wdl6812 from #1315 (Windows 11, Zen 2, release, median of 7):

| scale | main | this PR |
|---|---|---|
| 2.0 (648x846) | 28–33 ms | 21–22 ms |
| 4.0 (1296x1692) | 47–56 ms | 37–42 ms |

Drawing the masked image itself drops from 11.4 ms to 4.2 ms at scale 2.0. (Whole-page numbers are smaller than the ones in #1315 because those were measured against hayro 0.7.1; main is already faster. The remaining gap to MuPDF is dominated by JBIG2 decoding + 1-bit mask expansion, which is a separate concern.)

## Rendering differences

Because the mask is now multiplied into the image before sampling (rather than being sampled independently at canvas resolution), outputs are not bit-identical on pages with dimension-mismatched masks. In the test suite, 26 render tests (34 pages) show diffs: 11 pdfbox, 7 pdfjs, 4 corpus, 3 pdfium, 1 custom (`tile_clamp_bug`, plus `pdfbox_3000` page 7 and the others listed by the suite). I inspected the largest ones (`pdfjs_issue18896`, `pdfjs_issue18765`, `pdfbox_3000`, `corpus_0289093`, `tile_clamp_bug`) side by side: the differences are low-amplitude resampling deviations confined to the masked images, with no structural or edge-quality changes. On the #1315 file, a 4x zoom comparison actually looks slightly cleaner, since the base image now gets a proper Hermite upsample instead of nearest-neighbor. Happy to attach comparison crops if useful.

All other render tests are pixel-identical. (The `write::` tests fail on my Windows machine on unmodified main as well, so they appear unrelated.)

## Verification

- Full `hayro-tests` suite against baseline snapshots generated from main: only the 26 expected diffs above
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --exclude hayro-demo --exclude hayro-bench --tests --examples` and `cargo fmt --check` clean on Rust 1.92 (the version pinned in CI)
- `cargo hack check --each-feature -p hayro` — all combinations pass
- `RUSTDOCFLAGS="-D warnings" cargo doc -p hayro --no-deps` clean