### PR TITLE
hayro-interpret: Improve Unicode recovery for Type3 fonts

### DIFF
--- a/hayro-interpret/src/font/mod.rs
+++ b/hayro-interpret/src/font/mod.rs
@@ -94,6 +94,8 @@ impl Glyph<'_> {
     ///
     /// **For Type3 Fonts:**
     /// 1. `ToUnicode` cmap
+    /// 2. Glyph name → Unicode (via Adobe Glyph List)
+    /// 3. Unicode naming conventions (e.g., "uni0041", "u0041")
     ///
     /// Returns `None` if the Unicode value could not be determined.
     ///
@@ -103,6 +105,20 @@ impl Glyph<'_> {
         match self {
             Glyph::Outline(g) => g.as_unicode(),
             Glyph::Type3(g) => g.as_unicode(),
+        }
+    }
+
+    /// Return the original character code that selected this glyph in the
+    /// content stream.
+    ///
+    /// For simple fonts this is the single byte from the string operand, and
+    /// for CID fonts it is the code resolved by the encoding `CMap`. Consumers
+    /// performing text extraction can use this as a last-resort input when
+    /// [`Glyph::as_unicode`] returns `None`.
+    pub fn char_code(&self) -> u32 {
+        match self {
+            Glyph::Outline(g) => g.char_code(),
+            Glyph::Type3(g) => g.char_code(),
         }
     }
 }
@@ -198,6 +214,11 @@ impl OutlineGlyph {
         self.id
     }
 
+    /// Get the original character code that selected this glyph.
+    pub fn char_code(&self) -> u32 {
+        self.char_code
+    }
+
     /// Get the advance width for this glyph.
     ///
     /// The advance width is how far to move horizontally after drawing
@@ -245,9 +266,14 @@ impl<'a> Type3Glyph<'a> {
 
     /// Returns the Unicode code point for this glyph, if available.
     ///
-    /// Note: Type3 fonts can only provide Unicode via `ToUnicode` cmap.
+    /// See [`Glyph::as_unicode`] for details on the fallback chain used.
     pub fn as_unicode(&self) -> Option<BfString> {
         self.font.char_code_to_unicode(self.char_code)
+    }
+
+    /// Get the original character code that selected this glyph.
+    pub fn char_code(&self) -> u32 {
+        self.char_code
     }
 }
 

--- a/hayro-interpret/src/font/type3.rs
+++ b/hayro-interpret/src/font/type3.rs
@@ -3,7 +3,9 @@ use crate::context::Context;
 use crate::device::Device;
 use crate::font::glyph_simulator::GlyphSimulator;
 use crate::font::true_type::{Width, read_encoding, read_widths};
-use crate::font::{Encoding, GlyphRun, Type3Glyph, UNITS_PER_EM, read_to_unicode};
+use crate::font::{
+    Encoding, GlyphRun, Type3Glyph, UNITS_PER_EM, glyph_name_to_unicode, read_to_unicode,
+};
 use crate::interpret::state::TextState;
 use crate::util::RectExt;
 use crate::x_object::soft_mask::SoftMask;
@@ -79,12 +81,16 @@ impl<'a> Type3<'a> {
     }
 
     pub(crate) fn map_code(&self, code: u8) -> GlyphId {
+        self.code_to_ps_name(code)
+            .map(|g| self.glyph_simulator.string_to_glyph(g))
+            .unwrap_or(GlyphId::NOTDEF)
+    }
+
+    fn code_to_ps_name(&self, code: u8) -> Option<&str> {
         self.encodings
             .get(&code)
             .map(|s| s.as_str())
             .or_else(|| self.encoding.map_code(code))
-            .map(|g| self.glyph_simulator.string_to_glyph(g))
-            .unwrap_or(GlyphId::NOTDEF)
     }
 
     pub(crate) fn glyph_width(&self, code: u8) -> f32 {
@@ -96,10 +102,24 @@ impl<'a> Type3<'a> {
     }
 
     pub(crate) fn char_code_to_unicode(&self, char_code: u32) -> Option<BfString> {
-        // Type3 fonts can only provide Unicode via ToUnicode CMap.
-        self.to_unicode
-            .as_ref()
-            .and_then(|t| t.lookup_bf_string(char_code))
+        if let Some(to_unicode) = &self.to_unicode
+            && let Some(c) = to_unicode.lookup_bf_string(char_code)
+        {
+            // Skip null character mappings and fall back to glyph name
+            // lookup. Some PDFs have incorrect ToUnicode mappings that map
+            // to U+0000.
+            if c != BfString::Char('\0') {
+                return Some(c);
+            }
+        }
+
+        // Like simple outline fonts, fall back to the glyph name selected
+        // by the encoding.
+        u8::try_from(char_code)
+            .ok()
+            .and_then(|code| self.code_to_ps_name(code))
+            .and_then(glyph_name_to_unicode)
+            .map(BfString::Char)
     }
 
     pub(crate) fn render_glyph(


### PR DESCRIPTION
## Summary

Fixes #1331.

Two changes for Type3 text extraction:

1. **Glyph-name fallback for Type3 Unicode mapping.** `Type3::char_code_to_unicode`
   consulted only the `ToUnicode` CMap, so `Glyph::as_unicode()` returned `None`
   for every glyph of a Type3 font without one — even when the `Differences`
   array uses AGL-meaningful names that Type1/TrueType fonts would map. Type3
   now reuses the same chain as simple outline fonts: `ToUnicode` (with the
   existing U+0000 lenience), then the encoding-selected glyph name through
   `glyph_name_to_unicode`. The name resolution is shared with `map_code`
   through a new `code_to_ps_name` helper, mirroring `type1.rs`.

2. **Public `char_code()` accessor** on `Glyph`, `OutlineGlyph`, and
   `Type3Glyph` (through `Deref`, also reachable from `PositionedGlyph` in
   `draw_glyph_run`). Real-world Type3 fonts (e.g. PDFium's
   [`type3.in`](https://github.com/chromium/pdfium/blob/a84323421e94f484faca52dd9d027934eba42ab8/testing/resources/pixel/type3.in)
   fixture, `/Differences [65 /C1]`) carry neither `ToUnicode` nor mappable
   names, so `as_unicode()` legitimately stays `None`; viewers like MuPDF still
   extract text there by falling back to the raw character code. Exposing the
   code lets extraction consumers apply such a last-resort policy themselves,
   without hayro guessing inside `as_unicode()` (where a raw-code guess would
   fabricate garbage for symbolic fonts).

`Glyph::as_unicode` rustdoc is updated accordingly.

## Behavior

Probing every glyph delivered through `Device::draw_glyph_run` (probe and
repro-PDF generator in #1331), on the PDFium fixture shape and two
single-change variants:

| file | Encoding | ToUnicode | `as_unicode()` before | after |
|---|---|---|---|---|
| `variant_orig.pdf` (fixture shape) | `[65 /C1]` | – | `None` ×3 | `None` ×3, `char_code() == 65` now public |
| `variant_agl.pdf` | `[65 /A]` | – | `None` ×3 | `Some('A')` ×3 |
| `variant_tou.pdf` | `[65 /C1]` | ✓ | `Some('A')` ×3 | `Some('A')` ×3 (unchanged) |

Rendering is untouched; `map_code` still resolves names exactly as before.

## Testing

- `cargo fmt` / `cargo clippy -p hayro-interpret`: clean.
- Behavior verified with the minimal probe device from #1331 on the three
  repro PDFs (before/after outputs above).
- Happy to add a regression test in whatever form you prefer (the repro PDFs
  are tiny and BSD-licensed / self-generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
