### PR TITLE
Expose ActualText to interpretation devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "kurbo",
  "log",
  "moxcms",
+ "pdf-writer",
  "phf",
  "rustc-hash",
  "siphasher",

--- a/hayro-interpret/Cargo.toml
+++ b/hayro-interpret/Cargo.toml
@@ -25,6 +25,7 @@ rustc-hash = { workspace = true }
 
 [dev-dependencies]
 image = { workspace = true, features = ["png"] }
+pdf-writer = { workspace = true }
 
 [features]
 default = ["embed-fonts", "embed-cmaps"]

--- a/hayro-interpret/src/device.rs
+++ b/hayro-interpret/src/device.rs
@@ -4,6 +4,32 @@ use crate::{BlendMode, ClipPath, FillRule, Image};
 use crate::{DrawMode, DrawProps, ImageDrawProps};
 use kurbo::{BezPath, Rect, Shape};
 
+/// Properties attached to a marked-content sequence.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MarkedContentProperties<'a> {
+    mcid: Option<i32>,
+    actual_text: Option<&'a [u8]>,
+}
+
+impl<'a> MarkedContentProperties<'a> {
+    pub(crate) fn new(mcid: Option<i32>, actual_text: Option<&'a [u8]>) -> Self {
+        Self { mcid, actual_text }
+    }
+
+    /// The marked-content identifier, if present.
+    pub fn mcid(self) -> Option<i32> {
+        self.mcid
+    }
+
+    /// The raw PDF text-string bytes from `/ActualText`, if present.
+    ///
+    /// Consumers must decode these according to the PDF text-string encoding
+    /// rules.
+    pub fn actual_text(self) -> Option<&'a [u8]> {
+        self.actual_text
+    }
+}
+
 /// A trait for a device that can be used to process PDF drawing instructions.
 pub trait Device<'a> {
     /// Draw a path.
@@ -46,6 +72,19 @@ pub trait Device<'a> {
     /// The tag is the marked content tag (e.g. b"P", b"Span"). The mcid is
     /// the marked content identifier from the properties dict, if present.
     fn begin_marked_content(&mut self, _tag: &[u8], _mcid: Option<i32>) {}
+    /// Called at the beginning of a marked content sequence with a property
+    /// list (BDC).
+    ///
+    /// The default implementation forwards to [`Device::begin_marked_content`]
+    /// so devices that only need the marked-content identifier remain
+    /// compatible.
+    fn begin_marked_content_with_properties(
+        &mut self,
+        tag: &[u8],
+        properties: MarkedContentProperties<'_>,
+    ) {
+        self.begin_marked_content(tag, properties.mcid());
+    }
     /// Called at the end of a marked content sequence (EMC).
     fn end_marked_content(&mut self) {}
 }

--- a/hayro-interpret/src/interpret/mod.rs
+++ b/hayro-interpret/src/interpret/mod.rs
@@ -2,7 +2,7 @@ use crate::FillRule;
 use crate::color::ColorSpace;
 use crate::context::Context;
 use crate::convert::{convert_line_cap, convert_line_join};
-use crate::device::Device;
+use crate::device::{Device, MarkedContentProperties};
 use crate::font::{Font, FontData, FontQuery, StandardFont};
 use crate::interpret::path::{
     close_path, fill_path, fill_path_impl, fill_stroke_path, stroke_path,
@@ -15,8 +15,10 @@ use crate::util::{OptionLog, RectExt};
 use crate::x_object::{FormXObject, ImageXObject, XObject};
 use hayro_syntax::content::TypedIter;
 use hayro_syntax::content::ops::TypedInstruction;
-use hayro_syntax::object::dict::keys::{ANNOTS, AP, AS, F, MCID, N, OC, RECT};
-use hayro_syntax::object::{Array, Dict, Name, Object, Rect, Stream, dict_or_stream};
+use hayro_syntax::object::dict::keys::{ACTUAL_TEXT, ANNOTS, AP, AS, F, MCID, N, OC, RECT};
+use hayro_syntax::object::{
+    Array, Dict, Name, Object, Rect, Stream, String as PdfString, dict_or_stream,
+};
 use hayro_syntax::page::{Page, Resources};
 use kurbo::{Affine, Point, Shape};
 use rustc_hash::FxHashMap;
@@ -481,9 +483,18 @@ pub fn interpret<'a>(
             TypedInstruction::BeginMarkedContentWithProperties(bdc) => {
                 // Properties can be either:
                 // 1. A Name that references an entry in the Resources/Properties dictionary
-                // 2. An inline dictionary with an OC key
+                // 2. An inline property-list dictionary
 
-                let mcid = dict_or_stream(bdc.1).and_then(|(props, _)| props.get::<i32>(MCID));
+                let properties = bdc
+                    .1
+                    .clone()
+                    .into_name()
+                    .and_then(|name| resources.properties.get::<Dict<'_>>(name))
+                    .or_else(|| dict_or_stream(bdc.1).map(|(props, _)| props.clone()));
+                let mcid = properties.as_ref().and_then(|props| props.get::<i32>(MCID));
+                let actual_text = properties
+                    .as_ref()
+                    .and_then(|props| props.get::<PdfString<'_>>(ACTUAL_TEXT));
 
                 let oc = bdc
                     .1
@@ -510,7 +521,13 @@ pub fn interpret<'a>(
                     context.ocg_state.begin_marked_content();
                 }
 
-                device.begin_marked_content(bdc.0, mcid);
+                device.begin_marked_content_with_properties(
+                    bdc.0,
+                    MarkedContentProperties::new(
+                        mcid,
+                        actual_text.as_ref().map(PdfString::as_bytes),
+                    ),
+                );
             }
             TypedInstruction::MarkedContentPointWithProperties(_) => {}
             TypedInstruction::EndMarkedContent(_) => {

--- a/hayro-interpret/tests/marked_content.rs
+++ b/hayro-interpret/tests/marked_content.rs
@@ -1,0 +1,131 @@
+//! Marked-content callback integration tests.
+
+use hayro_interpret::font::GlyphRun;
+use hayro_interpret::{
+    BlendMode, ClipPath, Context, Device, DrawMode, DrawProps, Image, ImageDrawProps,
+    InterpreterCache, InterpreterSettings, MarkedContentProperties, SoftMask, interpret_page,
+};
+use hayro_syntax::Pdf;
+use kurbo::{Affine, BezPath, Rect};
+use pdf_writer::{Content, Name, Pdf as PdfWriter, Ref, TextStr};
+
+#[derive(Debug, PartialEq)]
+struct MarkedContentEvent {
+    tag: Vec<u8>,
+    mcid: Option<i32>,
+    actual_text: Option<Vec<u8>>,
+}
+
+#[derive(Default)]
+struct MarkedContentDevice {
+    events: Vec<MarkedContentEvent>,
+}
+
+impl Device<'_> for MarkedContentDevice {
+    fn draw_path(&mut self, _: &BezPath, _: DrawProps<'_>, _: &DrawMode) {}
+    fn push_clip_path(&mut self, _: &ClipPath) {}
+    fn push_transparency_group(&mut self, _: f32, _: Option<SoftMask<'_>>, _: BlendMode) {}
+    fn draw_glyph_run(&mut self, _: &GlyphRun<'_, '_>, _: DrawProps<'_>, _: &DrawMode) {}
+    fn draw_image(&mut self, _: Image<'_, '_>, _: ImageDrawProps<'_>) {}
+    fn pop_clip(&mut self) {}
+    fn pop_transparency_group(&mut self) {}
+
+    fn begin_marked_content(&mut self, tag: &[u8], mcid: Option<i32>) {
+        self.events.push(MarkedContentEvent {
+            tag: tag.to_vec(),
+            mcid,
+            actual_text: None,
+        });
+    }
+
+    fn begin_marked_content_with_properties(
+        &mut self,
+        tag: &[u8],
+        properties: MarkedContentProperties<'_>,
+    ) {
+        self.events.push(MarkedContentEvent {
+            tag: tag.to_vec(),
+            mcid: properties.mcid(),
+            actual_text: properties.actual_text().map(<[u8]>::to_vec),
+        });
+    }
+}
+
+#[test]
+fn marked_content_exposes_inline_and_named_actual_text() {
+    let pdf = Pdf::new(marked_content_pdf()).unwrap();
+    let page = &pdf.pages()[0];
+    let cache = InterpreterCache::new();
+    let mut context = Context::new(
+        Affine::IDENTITY,
+        Rect::new(0.0, 0.0, 100.0, 100.0),
+        &cache,
+        pdf.xref(),
+        InterpreterSettings::default(),
+    );
+    let mut device = MarkedContentDevice::default();
+
+    interpret_page(page, &mut context, &mut device);
+
+    assert_eq!(
+        device.events,
+        [
+            MarkedContentEvent {
+                tag: b"Span".to_vec(),
+                mcid: Some(7),
+                actual_text: Some(b"Inline".to_vec()),
+            },
+            MarkedContentEvent {
+                tag: b"Span".to_vec(),
+                mcid: Some(9),
+                actual_text: Some(b"Named".to_vec()),
+            },
+            MarkedContentEvent {
+                tag: b"P".to_vec(),
+                mcid: None,
+                actual_text: None,
+            },
+        ]
+    );
+}
+
+fn marked_content_pdf() -> Vec<u8> {
+    let mut pdf = PdfWriter::new();
+    let catalog_ref = Ref::new(1);
+    let pages_ref = Ref::new(2);
+    let page_ref = Ref::new(3);
+    let contents_ref = Ref::new(4);
+
+    pdf.catalog(catalog_ref).pages(pages_ref);
+    pdf.pages(pages_ref).kids([page_ref]).count(1);
+
+    {
+        let mut page = pdf.page(page_ref);
+        page.parent(pages_ref)
+            .media_box(pdf_writer::Rect::new(0.0, 0.0, 100.0, 100.0))
+            .contents(contents_ref);
+        page.resources()
+            .properties()
+            .insert(Name(b"Named"))
+            .identify(9)
+            .actual_text(TextStr("Named"));
+    }
+
+    let mut content = Content::new();
+    content
+        .begin_marked_content_with_properties(Name(b"Span"))
+        .properties()
+        .identify(7)
+        .actual_text(TextStr("Inline"));
+    content.end_marked_content();
+    content
+        .begin_marked_content_with_properties(Name(b"Span"))
+        .properties_named(Name(b"Named"));
+    content.end_marked_content();
+    content
+        .begin_marked_content(Name(b"P"))
+        .end_marked_content();
+    pdf.stream(contents_ref, &content.finish());
+
+    pdf.finish()
+}


### PR DESCRIPTION
## Summary

- expose marked-content properties to interpretation devices through a new additive callback
- include both `MCID` and raw `/ActualText` PDF text-string bytes
- resolve property lists supplied inline or by name through `Resources/Properties`
- preserve existing `Device::begin_marked_content` implementations through the new callback's default forwarding behavior

## Why

The interpreter already parses `BDC` property lists, but it only forwards an inline `MCID` to devices. `/ActualText` is therefore unavailable to text extractors even when a producer supplies the authoritative logical replacement for shaped, reordered, or otherwise non-one-to-one glyph content. Named property lists also do not currently expose their `MCID`.

Passing the raw PDF text-string bytes keeps decoding policy and allocation under the consumer's control. It also avoids changing the existing callback signature.

## Validation

- `cargo test -p hayro-interpret`
- `cargo test -p hayro-interpret --all-features`
- `cargo check -p hayro-interpret --no-default-features`
- `cargo fmt --all -- --check`

The new integration test constructs a PDF containing inline `ActualText`, a named property list, and a plain `BMC` sequence, then verifies the complete callback data.
