### PR TITLE
Reject non-rectangle traversals in path_as_rect

### DIFF
--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -379,6 +379,7 @@ pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
     let bbox = path.fast_bounding_box();
     let (min_x, min_y, max_x, max_y) = (bbox.min_x(), bbox.min_y(), bbox.max_x(), bbox.max_y());
     let mut corners = [false; 4];
+    let mut vertices: Vec<Point> = Vec::with_capacity(5);
 
     let mut check_point = |p: Point| {
         corners[0] |= p.x.is_nearly_equal(min_x) && p.y.is_nearly_equal(min_y);
@@ -395,17 +396,60 @@ pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
                 }
 
                 check_point(*p);
+                vertices.push(*p);
             }
-            PathEl::LineTo(l) => check_point(*l),
+            PathEl::LineTo(l) => {
+                check_point(*l);
+                vertices.push(*l);
+            }
             PathEl::QuadTo(_, _) => return None,
             PathEl::CurveTo(_, _, _) => return None,
-            PathEl::ClosePath => {}
+            // A ClosePath anywhere but the final element splits the path
+            // into a closed subpath plus trailing edges — not a rectangle
+            // outline, whatever the corner coverage says.
+            PathEl::ClosePath => {
+                if idx != path.elements().len() - 1 {
+                    return None;
+                }
+            }
         }
     }
 
-    if corners[0] && corners[1] && corners[2] && corners[3] {
-        Some(bbox)
-    } else {
-        None
+    if !(corners[0] && corners[1] && corners[2] && corners[3]) {
+        return None;
     }
+
+    // Touching all four bbox corners does not make a path a rectangle: a
+    // self-intersecting bowtie ("50 50 m 150 150 l 50 150 l 150 50 l h" —
+    // e.g. a P&ID valve symbol) touches every corner too, and classifying
+    // it as a rect fills/strokes/clips the FULL bbox where the fill rule
+    // should cancel the crossing (both rules leave two triangles).
+    // Require the traversal to be a genuine rectangle outline: exactly
+    // four distinct vertices — an explicit closing line back to the start
+    // is allowed and dropped — and every consecutive edge (with
+    // wraparound) axis-aligned and non-degenerate, i.e. its endpoints
+    // share EXACTLY one coordinate. A bowtie's diagonal shares neither, a
+    // repeated vertex shares both; either falls through to `draw_path`,
+    // which renders the true geometry under both fill rules. True
+    // rectangles from any start corner in either direction (including the
+    // `re` operator's output) still pass and keep the fast path.
+    if vertices.len() == 5 {
+        let (first, last) = (vertices[0], vertices[4]);
+        if !(last.x.is_nearly_equal(first.x) && last.y.is_nearly_equal(first.y)) {
+            return None;
+        }
+        vertices.truncate(4);
+    }
+    if vertices.len() != 4 {
+        return None;
+    }
+    for i in 0..4 {
+        let a = vertices[i];
+        let b = vertices[(i + 1) % 4];
+        if a.x.is_nearly_equal(b.x) == a.y.is_nearly_equal(b.y) {
+            return None;
+        }
+    }
+
+    Some(bbox)
 }

--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -371,68 +371,35 @@ impl<'a> Context<'a> {
 }
 
 pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
-    // One MoveTo, three LineTo, one ClosePath
-    if path.elements().len() != 5 {
-        return None;
-    }
-
-    let bbox = path.fast_bounding_box();
-    let (min_x, min_y, max_x, max_y) = (bbox.min_x(), bbox.min_y(), bbox.max_x(), bbox.max_y());
-    let mut corners = [false; 4];
-    let mut first_point = None;
-    let mut previous_point = None;
-
-    let mut check_point = |p: Point| {
-        corners[0] |= p.x.is_nearly_equal(min_x) && p.y.is_nearly_equal(min_y);
-        corners[1] |= p.x.is_nearly_equal(min_x) && p.y.is_nearly_equal(max_y);
-        corners[2] |= p.x.is_nearly_equal(max_x) && p.y.is_nearly_equal(min_y);
-        corners[3] |= p.x.is_nearly_equal(max_x) && p.y.is_nearly_equal(max_y);
+    let points = match path.elements() {
+        [
+            PathEl::MoveTo(first),
+            PathEl::LineTo(second),
+            PathEl::LineTo(third),
+            PathEl::LineTo(fourth),
+            PathEl::ClosePath,
+        ] => [*first, *second, *third, *fourth, *first],
+        [
+            PathEl::MoveTo(first),
+            PathEl::LineTo(second),
+            PathEl::LineTo(third),
+            PathEl::LineTo(fourth),
+            PathEl::LineTo(last),
+        ] if first.x.is_nearly_equal(last.x) && first.y.is_nearly_equal(last.y) => {
+            [*first, *second, *third, *fourth, *last]
+        }
+        _ => return None,
     };
 
-    for (idx, el) in path.elements().iter().enumerate() {
-        match el {
-            PathEl::MoveTo(p) => {
-                if idx != 0 {
-                    return None;
-                }
-
-                check_point(*p);
-                first_point = Some(*p);
-                previous_point = Some(*p);
-            }
-            PathEl::LineTo(l) => {
-                let previous = previous_point?;
-                if !previous.x.is_nearly_equal(l.x) && !previous.y.is_nearly_equal(l.y) {
-                    return None;
-                }
-
-                check_point(*l);
-                previous_point = Some(*l);
-            }
-            PathEl::QuadTo(_, _) => return None,
-            PathEl::CurveTo(_, _, _) => return None,
-            // A mid-path close creates multiple contours.
-            PathEl::ClosePath => {
-                if idx != path.elements().len() - 1 {
-                    return None;
-                }
-            }
-        }
-    }
-
-    if !(corners[0] && corners[1] && corners[2] && corners[3]) {
-        return None;
-    }
-
-    // Corner coverage alone also accepts self-intersecting bowties.
-    if matches!(path.elements().last(), Some(PathEl::LineTo(_))) {
-        let (Some(first), Some(last)) = (first_point, previous_point) else {
-            return None;
-        };
-        if !last.x.is_nearly_equal(first.x) || !last.y.is_nearly_equal(first.y) {
+    let mut previous_axis = None;
+    for edge in points.windows(2) {
+        let same_x = edge[0].x.is_nearly_equal(edge[1].x);
+        let same_y = edge[0].y.is_nearly_equal(edge[1].y);
+        if same_x == same_y || previous_axis == Some(same_x) {
             return None;
         }
+        previous_axis = Some(same_x);
     }
 
-    Some(bbox)
+    Some(path.fast_bounding_box())
 }

--- a/hayro-interpret/src/context.rs
+++ b/hayro-interpret/src/context.rs
@@ -379,7 +379,8 @@ pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
     let bbox = path.fast_bounding_box();
     let (min_x, min_y, max_x, max_y) = (bbox.min_x(), bbox.min_y(), bbox.max_x(), bbox.max_y());
     let mut corners = [false; 4];
-    let mut vertices: Vec<Point> = Vec::with_capacity(5);
+    let mut first_point = None;
+    let mut previous_point = None;
 
     let mut check_point = |p: Point| {
         corners[0] |= p.x.is_nearly_equal(min_x) && p.y.is_nearly_equal(min_y);
@@ -396,17 +397,21 @@ pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
                 }
 
                 check_point(*p);
-                vertices.push(*p);
+                first_point = Some(*p);
+                previous_point = Some(*p);
             }
             PathEl::LineTo(l) => {
+                let previous = previous_point?;
+                if !previous.x.is_nearly_equal(l.x) && !previous.y.is_nearly_equal(l.y) {
+                    return None;
+                }
+
                 check_point(*l);
-                vertices.push(*l);
+                previous_point = Some(*l);
             }
             PathEl::QuadTo(_, _) => return None,
             PathEl::CurveTo(_, _, _) => return None,
-            // A ClosePath anywhere but the final element splits the path
-            // into a closed subpath plus trailing edges — not a rectangle
-            // outline, whatever the corner coverage says.
+            // A mid-path close creates multiple contours.
             PathEl::ClosePath => {
                 if idx != path.elements().len() - 1 {
                     return None;
@@ -419,34 +424,12 @@ pub(crate) fn path_as_rect(path: &BezPath) -> Option<Rect> {
         return None;
     }
 
-    // Touching all four bbox corners does not make a path a rectangle: a
-    // self-intersecting bowtie ("50 50 m 150 150 l 50 150 l 150 50 l h" —
-    // e.g. a P&ID valve symbol) touches every corner too, and classifying
-    // it as a rect fills/strokes/clips the FULL bbox where the fill rule
-    // should cancel the crossing (both rules leave two triangles).
-    // Require the traversal to be a genuine rectangle outline: exactly
-    // four distinct vertices — an explicit closing line back to the start
-    // is allowed and dropped — and every consecutive edge (with
-    // wraparound) axis-aligned and non-degenerate, i.e. its endpoints
-    // share EXACTLY one coordinate. A bowtie's diagonal shares neither, a
-    // repeated vertex shares both; either falls through to `draw_path`,
-    // which renders the true geometry under both fill rules. True
-    // rectangles from any start corner in either direction (including the
-    // `re` operator's output) still pass and keep the fast path.
-    if vertices.len() == 5 {
-        let (first, last) = (vertices[0], vertices[4]);
-        if !(last.x.is_nearly_equal(first.x) && last.y.is_nearly_equal(first.y)) {
+    // Corner coverage alone also accepts self-intersecting bowties.
+    if matches!(path.elements().last(), Some(PathEl::LineTo(_))) {
+        let (Some(first), Some(last)) = (first_point, previous_point) else {
             return None;
-        }
-        vertices.truncate(4);
-    }
-    if vertices.len() != 4 {
-        return None;
-    }
-    for i in 0..4 {
-        let a = vertices[i];
-        let b = vertices[(i + 1) % 4];
-        if a.x.is_nearly_equal(b.x) == a.y.is_nearly_equal(b.y) {
+        };
+        if !last.x.is_nearly_equal(first.x) || !last.y.is_nearly_equal(first.y) {
             return None;
         }
     }

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -454,6 +454,10 @@
     "file": "pdfs/custom/page_rotation_none.pdf"
   },
   {
+    "id": "path_as_rect",
+    "file": "pdfs/custom/path_as_rect.pdf"
+  },
+  {
     "id": "path_rendering_1",
     "file": "pdfs/custom/path_rendering_1.pdf"
   },

--- a/hayro-tests/pdfs/custom/path_as_rect.pdf
+++ b/hayro-tests/pdfs/custom/path_as_rect.pdf
@@ -1,0 +1,192 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+/Title (path\137as\137rect variations)
+/Creator (Hayro regression fixture)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 6
+/Kids [ 4 0 R 6 0 R 8 0 R 10 0 R 12 0 R 14 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 5 0 R
+/Parent 2 0 R
+>>
+endobj
+5 0 obj
+<<
+/Length 29
+>>
+stream
+q
+0 g
+0 G
+10 10 80 80 re f
+Q
+
+endstream
+endobj
+6 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 7 0 R
+/Parent 2 0 R
+>>
+endobj
+7 0 obj
+<<
+/Length 48
+>>
+stream
+q
+0 g
+0 G
+10 10 m 90 90 l 10 90 l 90 10 l h f
+Q
+
+endstream
+endobj
+8 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 9 0 R
+/Parent 2 0 R
+>>
+endobj
+9 0 obj
+<<
+/Length 49
+>>
+stream
+q
+0 g
+0 G
+10 10 m 90 90 l 10 90 l 90 10 l h f*
+Q
+
+endstream
+endobj
+10 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 11 0 R
+/Parent 2 0 R
+>>
+endobj
+11 0 obj
+<<
+/Length 60
+>>
+stream
+q
+0 g
+0 G
+5 w
+1 J
+1 j
+10 10 m 90 90 l 10 90 l 90 10 l h S
+Q
+
+endstream
+endobj
+12 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 13 0 R
+/Parent 2 0 R
+>>
+endobj
+13 0 obj
+<<
+/Length 67
+>>
+stream
+q
+0 g
+0 G
+10 10 m 90 90 l 10 90 l 90 10 l h W n
+0 0 100 100 re f
+Q
+
+endstream
+endobj
+14 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 100 100 ]
+/Contents 15 0 R
+/Parent 2 0 R
+>>
+endobj
+15 0 obj
+<<
+/Length 68
+>>
+stream
+q
+0 g
+0 G
+10 10 m 90 90 l 10 90 l 90 10 l h W* n
+0 0 100 100 re f
+Q
+
+endstream
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000000015 00000 n 
+0000000129 00000 n 
+0000000221 00000 n 
+0000000270 00000 n 
+0000000380 00000 n 
+0000000459 00000 n 
+0000000569 00000 n 
+0000000667 00000 n 
+0000000777 00000 n 
+0000000876 00000 n 
+0000000988 00000 n 
+0000001099 00000 n 
+0000001211 00000 n 
+0000001329 00000 n 
+0000001441 00000 n 
+trailer
+<<
+/Size 16
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+1560
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -110,6 +110,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn page_rotation_270() { run_render_test("page_rotation_270", "pdfs/custom/page_rotation_270.pdf", None); }
 #[test] fn page_rotation_90() { run_render_test("page_rotation_90", "pdfs/custom/page_rotation_90.pdf", None); }
 #[test] fn page_rotation_none() { run_render_test("page_rotation_none", "pdfs/custom/page_rotation_none.pdf", None); }
+#[test] fn path_as_rect() { run_render_test("path_as_rect", "pdfs/custom/path_as_rect.pdf", None); }
 #[test] fn path_rendering_1() { run_render_test("path_rendering_1", "pdfs/custom/path_rendering_1.pdf", None); }
 #[test] fn path_rendering_10() { run_render_test("path_rendering_10", "pdfs/custom/path_rendering_10.pdf", None); }
 #[test] fn path_rendering_11() { run_render_test("path_rendering_11", "pdfs/custom/path_rendering_11.pdf", None); }


### PR DESCRIPTION
Fixes #1336.

Requires a genuine rectangle traversal before taking the rect fast path: exactly four distinct vertices (an explicit closing line back to the start is allowed and dropped), every consecutive edge axis-aligned and non-degenerate (endpoints share exactly one coordinate under `is_nearly_equal`), and `ClosePath` only as the final element. A bowtie's diagonal edge shares neither coordinate and falls through to `draw_path`, which renders the true geometry under both fill rules; true rectangles from any start corner in either direction (including `re` output) still classify.

Validated on the issue's repro: 320,000 ink px (two full quads) -> 159,200 (two triangle pairs, matching a collinear-split 6-element control on unmodified main and PDFium within AA). Happy to add a regression test wherever you prefer it in hayro-tests.