### PR TITLE
hayro-syntax: Better handling of invalid CCITT image heights

### DIFF
--- a/hayro-syntax/src/filter/ccitt.rs
+++ b/hayro-syntax/src/filter/ccitt.rs
@@ -17,7 +17,18 @@ pub(crate) fn decode(
     let k = params.get::<i32>(K).unwrap_or(0);
 
     let columns = params.get::<usize>(COLUMNS).unwrap_or(1728) as u32;
-    let rows = params.get::<u32>(ROWS).unwrap_or(image_params.height);
+    // Real-world producers mis-stamp /Rows below the image's true /Height
+    // (e.g. duplicating /Columns into /Rows), and honoring the smaller
+    // value truncates the decode: the undecoded remainder of the image
+    // renders as a solid block of sample 0. PDFium, Acrobat, and pdf.js
+    // all decode to the image height in that case, so clamp /Rows up to
+    // it. /Rows above the height is preserved (the decoder stops at
+    // end-of-data/EOFB regardless), and non-image streams pass height 0,
+    // making the clamp a no-op there.
+    let rows = params
+        .get::<u32>(ROWS)
+        .unwrap_or(0)
+        .max(image_params.height);
     let output_len = (columns as usize).checked_mul(rows as usize)?;
     let end_of_block = params.get::<bool>(END_OF_BLOCK).unwrap_or(true);
 

--- a/hayro-syntax/src/filter/ccitt.rs
+++ b/hayro-syntax/src/filter/ccitt.rs
@@ -17,14 +17,8 @@ pub(crate) fn decode(
     let k = params.get::<i32>(K).unwrap_or(0);
 
     let columns = params.get::<usize>(COLUMNS).unwrap_or(1728) as u32;
-    // Real-world producers mis-stamp /Rows below the image's true /Height
-    // (e.g. duplicating /Columns into /Rows), and honoring the smaller
-    // value truncates the decode: the undecoded remainder of the image
-    // renders as a solid block of sample 0. PDFium, Acrobat, and pdf.js
-    // all decode to the image height in that case, so clamp /Rows up to
-    // it. /Rows above the height is preserved (the decoder stops at
-    // end-of-data/EOFB regardless), and non-image streams pass height 0,
-    // making the clamp a no-op there.
+    // In case `Rows` is smaller than image height, take the image height.
+    // Seems to match what Chromium does.
     let rows = params
         .get::<u32>(ROWS)
         .unwrap_or(0)

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -252,6 +252,10 @@
     "file": "pdfs/custom/image_ccit_4.pdf"
   },
   {
+    "id": "image_ccitt_rows_below_height",
+    "file": "pdfs/custom/image_ccitt_rows_below_height.pdf"
+  },
+  {
     "id": "image_cmyk_icc_jpg",
     "file": "pdfs/custom/image_cmyk_icc_jpg.pdf"
   },

--- a/hayro-tests/pdfs/custom/image_ccitt_rows_below_height.pdf
+++ b/hayro-tests/pdfs/custom/image_ccitt_rows_below_height.pdf
@@ -1,0 +1,118 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [ 3 0 R ]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [ 0.0 0.0 200 100 ]
+/Resources <<
+/XObject <<
+/Im1 4 0 R
+>>
+>>
+/Contents 7 0 R
+/CropBox [ 0.0 0.0 200 100 ]
+>>
+endobj
+4 0 obj
+<<
+/Type /XObject
+/Subtype /Image
+/Width 16
+/Height 8
+/ColorSpace [ /Indexed /DeviceRGB 1 (\000\000\000\377\377\377) ]
+/BitsPerComponent 1
+/Filter [ /ASCIIHexDecode /CCITTFaxDecode ]
+/DecodeParms [ null <<
+/K -1
+/Columns 16
+/Rows 4
+>> ]
+/Length 17
+>>
+stream
+26A2FFE3E0020020>
+endstream
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+>>
+endobj
+6 0 obj
+<<
+/Length 253
+>>
+stream
+q
+200 0 0 100 50 100 cm
+/Im1 Do
+Q
+0 G
+1 w
+50 100 200 100 re S
+362 100 200 100 re S
+0 g
+362 150 100 50 re f
+BT
+/F1 16 Tf
+50 255 Td
+(CCITT /Rows 4, image /Height 8) Tj
+ET
+BT
+/F1 13 Tf
+50 75 Td
+(Rendered image) Tj
+ET
+BT
+/F1 13 Tf
+362 75 Td
+(Expected) Tj
+ET
+endstream
+endobj
+7 0 obj
+<<
+/Length 31
+>>
+stream
+q
+200 0 0 100 0 0 cm
+/Im1 Do
+Q
+
+endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000123 00000 n 
+0000000288 00000 n 
+0000000589 00000 n 
+0000000659 00000 n 
+0000000963 00000 n 
+trailer
+<<
+/Size 8
+/Root 1 0 R
+>>
+startxref
+1044
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -61,6 +61,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn image_ccit_1() { run_render_test("image_ccit_1", "pdfs/custom/image_ccit_1.pdf", None); }
 #[test] fn image_ccit_3() { run_render_test("image_ccit_3", "pdfs/custom/image_ccit_3.pdf", None); }
 #[test] fn image_ccit_4() { run_render_test("image_ccit_4", "pdfs/custom/image_ccit_4.pdf", None); }
+#[test] fn image_ccitt_rows_below_height() { run_render_test("image_ccitt_rows_below_height", "pdfs/custom/image_ccitt_rows_below_height.pdf", None); }
 #[test] fn image_cmyk_icc_jpg() { run_render_test("image_cmyk_icc_jpg", "pdfs/custom/image_cmyk_icc_jpg.pdf", None); }
 #[test] fn image_cmyk_jpg() { run_render_test("image_cmyk_jpg", "pdfs/custom/image_cmyk_jpg.pdf", None); }
 #[test] fn image_inline_2() { run_render_test("image_inline_2", "pdfs/custom/image_inline_2.pdf", None); }


### PR DESCRIPTION
Fixes #1337.

Clamps `DecodeParms /Rows` up to `ImageDecodeParams.height` in the CCITT filter, matching PDFium/Acrobat/pdf.js behavior on real-world files whose producers mis-stamp `/Rows` below the image height. `/Rows` above the height is preserved (the decoder stops at end-of-data/EOFB regardless), `/Rows` absent keeps the existing height fallback, and non-image streams pass height 0, making the clamp a no-op.

Validated on the issue's repro: 19,584 ink px (truncation block) -> 11,392, pixel-identical to PDFium on the same file. Happy to add a regression test wherever you prefer it in hayro-tests.