### PR TITLE
hayro-jpeg2000: Apply reconstruction midpoint to fully decoded irreversible coefficients

### DIFF
--- a/hayro-jpeg2000/src/j2c/bitplane.rs
+++ b/hayro-jpeg2000/src/j2c/bitplane.rs
@@ -275,21 +275,33 @@ impl CoefficientState {
 pub(crate) struct Coefficient(u32);
 
 impl Coefficient {
-    pub(crate) fn reconstructed(&self, state: &CoefficientState) -> i32 {
+    pub(crate) fn reconstructed(&self, state: &CoefficientState, quantised: bool) -> f32 {
         let mut magnitude = (self.0 & !0x80000000) as i32;
         // Map sign (0 for positive, 1 for negative) to 1, -1.
         magnitude *= 1 - 2 * (self.sign() as i32);
-
-        // See Formula E-6: In case the coefficient doesn't have full precision,
-        // we need to apply a reconstruction bias. The recommended value is
-        // 1/2.
-        let bit_position = state.decoded_bit_position();
-        if magnitude != 0 && bit_position != 0 {
-            let offset = 1 << (bit_position - 1);
-            magnitude += if magnitude > 0 { offset } else { -offset };
+        if magnitude == 0 {
+            return 0.0;
         }
 
-        magnitude
+        // Formula E-6 reconstructs a nonzero coefficient at `r * 2 ^ (Mb - Nb)` above its
+        // decoded magnitude, with r = 1/2 the usual midpoint. `Mb - Nb` is the number of
+        // magnitude bits that were never coded, so it is zero once a coefficient is fully
+        // decoded -- and the term is then r itself rather than nothing, because a
+        // quantisation interval of width Delta still surrounds the value.
+        //
+        // Without quantisation there is no such interval: a fully decoded coefficient is
+        // exact, and offsetting it by half would move a lossless image.
+        let bit_position = state.decoded_bit_position();
+        let offset = if bit_position == 0 {
+            if quantised {
+                0.5
+            } else {
+                return magnitude as f32;
+            }
+        } else {
+            0.5 * (1_u32 << bit_position) as f32
+        };
+        magnitude as f32 + if magnitude > 0 { offset } else { -offset }
     }
 
     fn set_sign(&mut self, sign: u8) {

--- a/hayro-jpeg2000/src/j2c/bitplane.rs
+++ b/hayro-jpeg2000/src/j2c/bitplane.rs
@@ -275,33 +275,20 @@ impl CoefficientState {
 pub(crate) struct Coefficient(u32);
 
 impl Coefficient {
-    pub(crate) fn reconstructed(&self, state: &CoefficientState, quantised: bool) -> f32 {
+    pub(crate) fn reconstructed(&self, state: &CoefficientState, irreversible: bool) -> f32 {
         let mut magnitude = (self.0 & !0x80000000) as i32;
         // Map sign (0 for positive, 1 for negative) to 1, -1.
         magnitude *= 1 - 2 * (self.sign() as i32);
-        if magnitude == 0 {
-            return 0.0;
+
+        // See Formulas E-6 to E-8: Apply the reconstruction midpoint unless a
+        // reversible coefficient has been fully decoded, in which case it is exact.
+        let bit_position = state.decoded_bit_position();
+        if magnitude != 0 && (irreversible || bit_position != 0) {
+            let offset = 0.5 * (1_u32 << bit_position) as f32;
+            return magnitude as f32 + if magnitude > 0 { offset } else { -offset };
         }
 
-        // Formula E-6 reconstructs a nonzero coefficient at `r * 2 ^ (Mb - Nb)` above its
-        // decoded magnitude, with r = 1/2 the usual midpoint. `Mb - Nb` is the number of
-        // magnitude bits that were never coded, so it is zero once a coefficient is fully
-        // decoded -- and the term is then r itself rather than nothing, because a
-        // quantisation interval of width Delta still surrounds the value.
-        //
-        // Without quantisation there is no such interval: a fully decoded coefficient is
-        // exact, and offsetting it by half would move a lossless image.
-        let bit_position = state.decoded_bit_position();
-        let offset = if bit_position == 0 {
-            if quantised {
-                0.5
-            } else {
-                return magnitude as f32;
-            }
-        } else {
-            0.5 * (1_u32 << bit_position) as f32
-        };
-        magnitude as f32 + if magnitude > 0 { offset } else { -offset }
+        magnitude as f32
     }
 
     fn set_sign(&mut self, sign: u8) {

--- a/hayro-jpeg2000/src/j2c/decode.rs
+++ b/hayro-jpeg2000/src/j2c/decode.rs
@@ -9,7 +9,9 @@ use alloc::vec::Vec;
 
 use super::bitplane::{BitPlaneDecodeBuffers, BitPlaneDecodeContext};
 use super::build::{CodeBlock, Decomposition, Layer, Precinct, Segment, SubBand, SubBandType};
-use super::codestream::{ComponentInfo, Header, ProgressionOrder, QuantizationStyle};
+use super::codestream::{
+    ComponentInfo, Header, ProgressionOrder, QuantizationStyle, WaveletTransform,
+};
 use super::idwt::IDWTOutput;
 use super::progression::{
     IteratorInput, ProgressionData, component_position_resolution_layer_progression,
@@ -338,6 +340,7 @@ fn decode_sub_band_bitplanes(
 
     let quantised =
         component_info.quantization_info.quantization_style != QuantizationStyle::NoQuantization;
+    let irreversible = component_info.wavelet_transform() == WaveletTransform::Irreversible97;
     let dequantization_step = {
         if !quantised {
             1.0
@@ -412,7 +415,7 @@ fn decode_sub_band_bitplanes(
                 for ((output, coefficient), coefficient_state) in
                     out_row.iter_mut().zip(coefficients).zip(coefficient_states)
                 {
-                    *output = coefficient.reconstructed(coefficient_state, quantised);
+                    *output = coefficient.reconstructed(coefficient_state, irreversible);
                     *output *= dequantization_step;
                 }
 

--- a/hayro-jpeg2000/src/j2c/decode.rs
+++ b/hayro-jpeg2000/src/j2c/decode.rs
@@ -336,9 +336,10 @@ fn decode_sub_band_bitplanes(
 ) -> Result<()> {
     let sub_band = &storage.sub_bands[sub_band_idx];
 
+    let quantised =
+        component_info.quantization_info.quantization_style != QuantizationStyle::NoQuantization;
     let dequantization_step = {
-        if component_info.quantization_info.quantization_style == QuantizationStyle::NoQuantization
-        {
+        if !quantised {
             1.0
         } else {
             let (exponent, mantissa) =
@@ -411,7 +412,7 @@ fn decode_sub_band_bitplanes(
                 for ((output, coefficient), coefficient_state) in
                     out_row.iter_mut().zip(coefficients).zip(coefficient_states)
                 {
-                    *output = coefficient.reconstructed(coefficient_state) as f32;
+                    *output = coefficient.reconstructed(coefficient_state, quantised);
                     *output *= dequantization_step;
                 }
 


### PR DESCRIPTION
Apply the reconstruction midpoint to fully decoded coefficients

Formula E-6 reconstructs a nonzero quantised coefficient at r · 2^(Mb − Nb) above its decoded magnitude. Mb − Nb is the number of magnitude bits that were never coded, so it is zero once a coefficient is fully decoded — and 2^0 = 1, which makes the term r itself rather than nothing. The quantisation interval of width Δ still surrounds the value.

#1284 added the term but skipped it in exactly that case, so every fully decoded coefficient landed on the edge of its interval instead of the middle. That is invisible on coarsely quantised images, where most coefficients are truncated and #1284 already dominates, and it is the whole error on finely quantised ones, where almost every coefficient is complete.

Without quantisation there is no interval and a fully decoded coefficient is exact, so the offset is skipped there — otherwise a lossless image moves by half a level. That case is why reconstruction now takes the quantisation style; it also lets the offset be a float, which it has to be, since half a unit is not an integer.

Measured against opj_decompress over 30 codestreams taken from the pdf.js test corpus, on top of #1284:

```
S2.pdf object 17      53 286 samples wrong, worst by 3  ->    325, worst by 1
S2.pdf object 19      34 908, worst by 3                ->    436, worst by 1
issue5475.pdf obj 8   91 144, worst by 2                ->     48, worst by 1
issue5481.pdf obj 5    1 076 388, worst by 4            ->    546, worst by 1
issue5549.pdf obj 11     965 165, worst by 5            ->  2 494, worst by 1
```

Roughly 3.4 million differing samples become 5 900, and no remaining difference exceeds one level. The fourteen codestreams that were already byte-identical — all of them reversible — stay byte-identical, and test_jpeg2000_standard_example_b4 still passes.

Found by bisecting on resolution: issue5475.pdf object 8 has numresolutions=2, so decoding at -r 1 stops at the LL sub-band with no 9/7 synthesis, and the disagreement was still there — which places it in dequantisation. The residual then proved symmetric and confined to fractional parts in (0.25, 0.75), the signature of two floats a quarter-level apart.