### PR TITLE
hayro-syntax: fix races in concurrent object resolution on a shared Pdf

### DIFF
--- a/hayro-syntax/src/data.rs
+++ b/hayro-syntax/src/data.rs
@@ -92,22 +92,172 @@ impl Data {
 
     /// Get access to the data of a decoded object stream.
     pub(crate) fn get_with(&self, id: ObjectIdentifier, ctx: &ReaderContext<'_>) -> Option<&[u8]> {
-        if let Some(&idx) = self.map.get().get(&id) {
-            self.decoded.get(idx)?.as_deref()
-        } else {
-            // Block scope to keep the lock short-lived.
-            let idx = {
-                let mut locked = self.map.get();
-                let idx = locked.len();
-                locked.insert(id, idx);
-                idx
-            };
-            self.decoded
-                .get_or_init(idx, || {
-                    let stream = ctx.xref().get_with::<Stream<'_>>(id, ctx)?;
-                    stream.decoded().ok().map(Cow::into_owned)
-                })
-                .as_deref()
+        // Resolve the slot index with a single locked check-or-insert, and
+        // always go through `get_or_init` afterwards. The map insert and
+        // the slot initialization are not atomic, so a concurrent reader
+        // can observe the map entry while the inserting thread is still
+        // decoding the stream; it has to block in `get_or_init` until the
+        // slot is initialized. Reading the slot with the non-blocking
+        // `SegmentList::get` at that point would silently treat every
+        // object in the object stream as null. The single check-or-insert
+        // also keeps two racing threads from inserting the same id twice.
+        //
+        // Block scope to keep the lock short-lived; in particular, it must
+        // not be held while decoding.
+        let idx = {
+            let mut locked = self.map.get();
+            match locked.get(&id) {
+                Some(&idx) => idx,
+                None => {
+                    let idx = locked.len();
+                    locked.insert(id, idx);
+                    idx
+                }
+            }
+        };
+        self.decoded
+            .get_or_init(idx, || {
+                let stream = ctx.xref().get_with::<Stream<'_>>(id, ctx)?;
+                stream.decoded().ok().map(Cow::into_owned)
+            })
+            .as_deref()
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use crate::object::ObjectIdentifier;
+    use crate::object::dict::Dict;
+    use crate::pdf::Pdf;
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// The number of objects stored inside the object stream.
+    const NUM_MEMBERS: usize = 12;
+    /// The object number of the first object inside the object stream.
+    const FIRST_MEMBER: usize = 5;
+
+    /// Build an uncompressed PDF whose objects `5..(5 + NUM_MEMBERS)` live in
+    /// an object stream (object 3), referenced from a cross-reference
+    /// stream (object 4). The object stream carries `padding` bytes of
+    /// trailing white space so that decoding it takes long enough for
+    /// concurrent readers to actually race the decode.
+    fn objstm_pdf(padding: usize) -> Vec<u8> {
+        // The members are `<< /V 105 >>`, `<< /V 106 >>`, ...
+        let mut pairs = String::new();
+        let mut payload = String::new();
+        for i in 0..NUM_MEMBERS {
+            let obj_num = FIRST_MEMBER + i;
+            pairs.push_str(&format!("{obj_num} {} ", payload.len()));
+            payload.push_str(&format!("<< /V {} >>\n", 100 + obj_num));
         }
+        let first = pairs.len();
+        let stream_len = first + payload.len() + padding;
+
+        let mut pdf: Vec<u8> = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.5\n");
+
+        let catalog_offset = pdf.len();
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        let pages_offset = pdf.len();
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+        let objstm_offset = pdf.len();
+        pdf.extend_from_slice(
+            format!(
+                "3 0 obj\n<< /Type /ObjStm /N {NUM_MEMBERS} /First {first} /Length {stream_len} >>\nstream\n"
+            )
+            .as_bytes(),
+        );
+        pdf.extend_from_slice(pairs.as_bytes());
+        pdf.extend_from_slice(payload.as_bytes());
+        pdf.extend(core::iter::repeat_n(b' ', padding));
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+        // The cross-reference stream (object 4).
+        let size = FIRST_MEMBER + NUM_MEMBERS;
+        let xref_offset = pdf.len();
+        let mut entries: Vec<u8> = Vec::new();
+        let normal = |entries: &mut Vec<u8>, offset: usize| {
+            entries.push(1);
+            entries.extend_from_slice(&(offset as u32).to_be_bytes());
+            entries.extend_from_slice(&[0, 0]);
+        };
+        // Object 0 is free.
+        entries.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0]);
+        normal(&mut entries, catalog_offset);
+        normal(&mut entries, pages_offset);
+        normal(&mut entries, objstm_offset);
+        normal(&mut entries, xref_offset);
+        for i in 0..NUM_MEMBERS {
+            // Type 2: stored in object stream 3 at index i.
+            entries.push(2);
+            entries.extend_from_slice(&3_u32.to_be_bytes());
+            entries.extend_from_slice(&(i as u16).to_be_bytes());
+        }
+
+        pdf.extend_from_slice(
+            format!(
+                "4 0 obj\n<< /Type /XRef /Size {size} /W [1 4 2] /Root 1 0 R /Length {} >>\nstream\n",
+                entries.len()
+            )
+            .as_bytes(),
+        );
+        pdf.extend_from_slice(&entries);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+        pdf.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+
+        pdf
+    }
+
+    /// All threads resolve the members of one shared object stream at the
+    /// same time. Whichever thread inserts the map entry decodes the
+    /// stream; every other thread must block until the decoded data is
+    /// available instead of silently resolving the members as null.
+    #[test]
+    fn concurrent_object_stream_resolution_is_not_null() {
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 32;
+
+        let data = objstm_pdf(2_000_000);
+        // Make sure the file itself is well-formed.
+        assert_eq!(Pdf::new(data.clone()).unwrap().xref().len(), 16);
+
+        let wrong = AtomicUsize::new(0);
+
+        for _ in 0..ITERATIONS {
+            let pdf = Pdf::new(data.clone()).unwrap();
+            let barrier = Barrier::new(THREADS);
+
+            std::thread::scope(|s| {
+                for _ in 0..THREADS {
+                    s.spawn(|| {
+                        barrier.wait();
+
+                        for i in 0..NUM_MEMBERS {
+                            let obj_num = (FIRST_MEMBER + i) as i32;
+                            let id = ObjectIdentifier::new(obj_num, 0);
+                            let value = pdf
+                                .xref()
+                                .get::<Dict<'_>>(id)
+                                .and_then(|d| d.get::<i32>(b"V"));
+
+                            if value != Some(100 + obj_num) {
+                                wrong.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        assert_eq!(
+            wrong.load(Ordering::Relaxed),
+            0,
+            "some object stream members resolved incorrectly under concurrency"
+        );
     }
 }

--- a/hayro-syntax/src/sync.rs
+++ b/hayro-syntax/src/sync.rs
@@ -73,8 +73,7 @@ impl<T> MutexExt<T> for Mutex<T> {
 
 pub(crate) trait RwLockExt<T> {
     fn get(&self) -> RwLockReadGuard<'_, T>;
-    fn try_get(&self) -> Option<RwLockReadGuard<'_, T>>;
-    fn try_put(&self) -> Option<RwLockWriteGuard<'_, T>>;
+    fn put(&self) -> RwLockWriteGuard<'_, T>;
 }
 
 #[cfg(feature = "std")]
@@ -83,12 +82,8 @@ impl<T> RwLockExt<T> for RwLock<T> {
         self.read().unwrap()
     }
 
-    fn try_get(&self) -> Option<RwLockReadGuard<'_, T>> {
-        self.try_read().ok()
-    }
-
-    fn try_put(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        self.try_write().ok()
+    fn put(&self) -> RwLockWriteGuard<'_, T> {
+        self.write().unwrap()
     }
 }
 
@@ -98,11 +93,7 @@ impl<T> RwLockExt<T> for RwLock<T> {
         self.borrow()
     }
 
-    fn try_get(&self) -> Option<RwLockReadGuard<'_, T>> {
-        Some(self.borrow())
-    }
-
-    fn try_put(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        Some(self.borrow_mut())
+    fn put(&self) -> RwLockWriteGuard<'_, T> {
+        self.borrow_mut()
     }
 }

--- a/hayro-syntax/src/util.rs
+++ b/hayro-syntax/src/util.rs
@@ -148,6 +148,12 @@ impl<T, const C: usize> SegmentList<T, C> {
         Self(core::array::from_fn(|_| OnceLock::new()))
     }
 
+    // Note that `get` does not synchronize with a concurrently running
+    // `get_or_init` on the same index: it returns `None` until the
+    // initializer has finished. Callers that need the value must use
+    // `get_or_init` instead (`Data::get_with` used to read initialized
+    // slots through `get` and silently lost the race).
+    #[cfg(test)]
     pub(crate) fn get(&self, i: usize) -> Option<&T> {
         let (s, k) = self.locate(i);
         let segment = self.0[s as usize].get()?;

--- a/hayro-syntax/src/xref.rs
+++ b/hayro-syntax/src/xref.rs
@@ -381,16 +381,6 @@ impl XRef {
         Ok(xref)
     }
 
-    fn is_repaired(&self) -> bool {
-        match &self.0 {
-            Inner::Dummy => false,
-            Inner::Some(r) => {
-                let locked = r.map.get();
-                locked.repaired
-            }
-        }
-    }
-
     pub(crate) fn dummy() -> &'static Self {
         &DUMMY_XREF
     }
@@ -482,8 +472,19 @@ impl XRef {
             unreachable!();
         };
 
-        let mut locked = r.map.try_put().unwrap();
-        assert!(!locked.repaired);
+        // Block until concurrent readers of the map have drained;
+        // `get_with` drops its read guard before calling `repair`, so no
+        // thread ever waits here while holding the map lock. Several
+        // threads can race into `repair` after each observing a broken
+        // entry: the first one rebuilds the map and the others simply
+        // return once the write lock is theirs, making the repair
+        // idempotent. In the uncontended (single-threaded) case the lock
+        // is acquired immediately and `repaired` is false, because the
+        // caller checked it before calling `repair`.
+        let mut locked = r.map.put();
+        if locked.repaired {
+            return;
+        }
 
         let (xref_map, _) = fallback_xref_map(r.data.get(), &r.password);
         locked.xref_map = xref_map;
@@ -541,7 +542,10 @@ impl XRef {
             return None;
         };
 
-        let locked = repr.map.try_get().unwrap();
+        // A blocking read: another thread might be repairing the xref
+        // table at this very moment, in which case we need to wait for the
+        // repaired map instead of panicking on a failed try-lock.
+        let locked = repr.map.get();
 
         let mut r = Reader::new(repr.data.get().as_ref());
 
@@ -550,6 +554,17 @@ impl XRef {
             // shall be treated as a reference to the null object.
             None
         })?;
+        // Snapshot the repaired flag under the same guard as the entry
+        // read. If parsing the entry fails below, the question to ask is
+        // "did the entry come from the pre-repair or the post-repair
+        // map?", not "is the map repaired by now?": with concurrent
+        // readers, a thread that read a stale pre-repair entry could
+        // otherwise observe another thread's repair that completed in the
+        // meantime, conclude that repairing has already been tried for
+        // its object, and silently resolve it as null, where the
+        // single-threaded path would repair and retry. Without
+        // concurrency, the snapshot and a fresh read are the same value.
+        let was_repaired = locked.repaired;
         drop(locked);
 
         let mut ctx = ctx.clone();
@@ -574,7 +589,13 @@ impl XRef {
                 };
 
                 // The xref table is broken, try to repair if not already repaired.
-                if self.is_repaired() {
+                // This branches on the snapshot taken above: an entry from
+                // the pre-repair map must retry against the repaired map
+                // even if another thread finished the repair in the
+                // meantime (`repair` is idempotent and blocks until the
+                // map is repaired, so the retry below reads the repaired
+                // entry either way).
+                if was_repaired {
                     error!(
                         "attempt was made at repairing xref, but object {id:?} still couldn't be read"
                     );
@@ -1150,5 +1171,177 @@ mod tests {
         let data = b"xref\n0 999999999999999999999\ntrailer\n<<>>";
         let mut reader = Reader::new(data);
         assert!(read_xref_table_trailer(&mut reader, &ReaderContext::dummy()).is_none());
+    }
+
+    /// The number of objects with deliberately broken xref entries in
+    /// [`broken_xref_pdf`].
+    #[cfg(feature = "std")]
+    const NUM_BROKEN: usize = 8;
+    /// The object number of the first broken object in [`broken_xref_pdf`].
+    #[cfg(feature = "std")]
+    const FIRST_BROKEN: usize = 3;
+
+    /// Build a PDF whose catalog and page tree entries are valid (so that
+    /// loading it does not trigger a repair), but whose xref entries for
+    /// objects `3..(3 + NUM_BROKEN)` point into the header, where neither
+    /// parsing nor skipping an indirect object succeeds. Resolving any of
+    /// those objects therefore takes the repair path. The `filler`
+    /// objects only make the file larger so that the full-file scan of a
+    /// repair takes long enough for concurrent readers to actually race
+    /// it.
+    #[cfg(feature = "std")]
+    fn broken_xref_pdf(filler: usize) -> Vec<u8> {
+        use alloc::format;
+        use alloc::string::String;
+        use alloc::vec::Vec;
+
+        let mut pdf: Vec<u8> = b"%PDF-1.4\n".to_vec();
+        let mut offsets: Vec<usize> = Vec::new();
+
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+        for i in 0..NUM_BROKEN {
+            let obj_num = FIRST_BROKEN + i;
+            offsets.push(pdf.len());
+            pdf.extend_from_slice(
+                format!("{obj_num} 0 obj\n<< /V {} >>\nendobj\n", 100 + obj_num).as_bytes(),
+            );
+        }
+
+        let first_filler = FIRST_BROKEN + NUM_BROKEN;
+        let filler_payload = "A".repeat(2000);
+        for i in 0..filler {
+            let obj_num = first_filler + i;
+            offsets.push(pdf.len());
+            pdf.extend_from_slice(
+                format!("{obj_num} 0 obj\n<< /Filler ({filler_payload}) >>\nendobj\n").as_bytes(),
+            );
+        }
+
+        let size = first_filler + filler;
+        let xref_pos = pdf.len();
+        let mut table = String::from("xref\n");
+        table.push_str(&format!("0 {size}\n"));
+        table.push_str("0000000000 65535 f\r\n");
+        for (i, offset) in offsets.iter().enumerate() {
+            let obj_num = i + 1;
+            let broken = (FIRST_BROKEN..FIRST_BROKEN + NUM_BROKEN).contains(&obj_num);
+            // Offset 2 points at the `DF-1.4` bytes of the header, where
+            // both reading and skipping an indirect object fail.
+            let offset = if broken { 2 } else { *offset };
+            table.push_str(&format!("{offset:010} 00000 n\r\n"));
+        }
+        table.push_str(&format!(
+            "trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF"
+        ));
+        pdf.extend_from_slice(table.as_bytes());
+
+        pdf
+    }
+
+    /// Every thread resolves its own broken object, so all of them race
+    /// into the repair path at once. The losing threads must wait for the
+    /// winning repair and then converge on the repaired table instead of
+    /// panicking on a failed try-lock or on a repeated repair.
+    #[cfg(feature = "std")]
+    #[test]
+    fn concurrent_repair_of_broken_xref_does_not_panic() {
+        use crate::object::dict::Dict;
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const ITERATIONS: usize = 16;
+
+        let data = broken_xref_pdf(300);
+        let wrong = AtomicUsize::new(0);
+
+        for _ in 0..ITERATIONS {
+            let pdf = crate::pdf::Pdf::new(data.clone()).unwrap();
+            let barrier = Barrier::new(NUM_BROKEN);
+
+            std::thread::scope(|s| {
+                for t in 0..NUM_BROKEN {
+                    let barrier = &barrier;
+                    let pdf = &pdf;
+                    let wrong = &wrong;
+                    s.spawn(move || {
+                        barrier.wait();
+
+                        let obj_num = (FIRST_BROKEN + t) as i32;
+                        let id = ObjectIdentifier::new(obj_num, 0);
+                        let value = pdf
+                            .xref()
+                            .get::<Dict<'_>>(id)
+                            .and_then(|d| d.get::<i32>(b"V"));
+
+                        if value != Some(100 + obj_num) {
+                            wrong.fetch_add(1, Ordering::Relaxed);
+                        }
+                    });
+                }
+            });
+        }
+
+        assert_eq!(
+            wrong.load(Ordering::Relaxed),
+            0,
+            "some objects failed to resolve after a concurrent xref repair"
+        );
+    }
+
+    /// All threads resolve the same broken objects. A thread that read a
+    /// stale pre-repair entry and then lost the repair race to another
+    /// thread must still retry against the repaired table instead of
+    /// silently resolving the object as null.
+    #[cfg(feature = "std")]
+    #[test]
+    fn concurrent_repair_does_not_null_pre_repair_entries() {
+        use crate::object::dict::Dict;
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 24;
+
+        let data = broken_xref_pdf(300);
+        let wrong = AtomicUsize::new(0);
+
+        for _ in 0..ITERATIONS {
+            let pdf = crate::pdf::Pdf::new(data.clone()).unwrap();
+            let barrier = Barrier::new(THREADS);
+
+            std::thread::scope(|s| {
+                for _ in 0..THREADS {
+                    let barrier = &barrier;
+                    let pdf = &pdf;
+                    let wrong = &wrong;
+                    s.spawn(move || {
+                        barrier.wait();
+
+                        for i in 0..NUM_BROKEN {
+                            let obj_num = (FIRST_BROKEN + i) as i32;
+                            let id = ObjectIdentifier::new(obj_num, 0);
+                            let value = pdf
+                                .xref()
+                                .get::<Dict<'_>>(id)
+                                .and_then(|d| d.get::<i32>(b"V"));
+
+                            if value != Some(100 + obj_num) {
+                                wrong.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    });
+                }
+            });
+        }
+
+        assert_eq!(
+            wrong.load(Ordering::Relaxed),
+            0,
+            "a lost repair race silently resolved objects as null"
+        );
     }
 }


### PR DESCRIPTION
<!-- Branch: fix/concurrent-object-resolution-races (two commits) -->

Fixes #1343. <!-- replace with the issue number at filing time -->

Two commits, one per resolution path; single-threaded behavior is unchanged by both (uncontended locks acquire immediately, and the removed assert's condition was already guaranteed by the caller's check).

**Commit 1 — object streams (data.rs, util.rs).** `Data::get_with` now resolves the slot index with a single locked check-or-insert and goes through the OnceLock-backed `get_or_init` on both the hit and the miss path, so a reader that observes the map entry while the inserting thread is still decoding blocks until the slot is initialized instead of silently resolving every member of the object stream as null. The single check-or-insert also removes the racing double-insert of the same id. `SegmentList::get` loses its last non-test caller and becomes `#[cfg(test)]`, with its non-synchronizing semantics documented.

**Commit 2 — broken-xref repair (xref.rs, sync.rs).** `repair` takes a blocking write lock and is idempotent: a thread that loses the repair race returns once the write lock is briefly theirs, instead of panicking on `try_put().unwrap()` or on `assert!(!locked.repaired)`. `get_with` takes a blocking read lock instead of `try_get().unwrap()`, and snapshots the repaired flag under the same guard as the entry read: the parse-failure branch asks "did the entry I failed to parse come from the pre- or post-repair map?", not "is the map repaired by now?", so a thread that read a stale pre-repair entry and lost the repair race retries against the repaired map instead of silently resolving its object as null. No call path holds the map lock while calling `repair` (`get_with` drops its read guard before), so the blocking locks cannot self-deadlock. `RwLockExt` gains the blocking `put()` (std and no-std impls); `try_get`/`try_put` lose their last callers and are removed, as does `is_repaired`.

## Tests

Three concurrency tests (in-file unit tests, `#[cfg(feature = "std")]`, fully synthetic in-memory PDFs built with computed offsets):

- `data::tests::concurrent_object_stream_resolution_is_not_null` — 8 threads resolve the 12 members of one shared object stream behind a barrier, 32 fresh `Pdf`s; the object stream is padded so the decode is long enough to race.
- `xref::tests::concurrent_repair_of_broken_xref_does_not_panic` — 8 threads each resolve their own broken-entry object, racing into the repair path at once, 16 fresh `Pdf`s.
- `xref::tests::concurrent_repair_does_not_null_pre_repair_entries` — 8 threads resolve the same 8 broken-entry objects, 24 fresh `Pdf`s, catching the lost-race silent null.

On main all three fail immediately and repeatably (measured on Windows x64, 8 threads; the panic/null split varies run to run, the totals do not):

| test | main @ cc9c4024 | this branch |
|---|---|---|
| object stream members | 2640–2688 of 3072 resolutions null/wrong | 0, 10/10 repeat runs green |
| repair, distinct objects | threads panic at xref.rs:544 / xref.rs:485 | all resolve, 10/10 green |
| repair, shared objects | threads panic (same sites) | all resolve, 10/10 green |

A separate counting harness on the same broken-xref document (120 thread resolutions): main panics in 78–103 and silently nulls 2–27, with exactly 15 correct — one per iteration, the thread that wins the repair. With commit 2's locking fixed but the stale flag re-read deliberately reintroduced, panics drop to 0 but some resolutions still silently null on every run (1–35 of 120 across repeated runs, varying with scheduling), and the third test catches that state on every run — that is the defect the snapshot fixes.

The commits are individually green (commit 1's test does not need the repair fixes), and the full hayro-syntax suite passes on both.
