### PR TITLE
Improve handling of extreme CTMs

### DIFF
--- a/hayro-interpret/src/interpret/path.rs
+++ b/hayro-interpret/src/interpret/path.rs
@@ -1,6 +1,6 @@
 use crate::context::{Context, path_as_rect};
 use crate::device::Device;
-use crate::util::{BezPathExt, Float32Ext};
+use crate::util::{BezPathExt, Float32Ext, x_y_advances};
 use crate::{DrawMode, FillRule, StrokeProps};
 use kurbo::{BezPath, Cap, Join, PathEl};
 
@@ -57,10 +57,10 @@ pub(crate) fn fill_path_impl<'a>(
     let mut draw = |path: &BezPath| {
         // pdf.js issue 4260: Replace zero-sized paths with a small stroke instead.
         let bbox = path.fast_bounding_box();
-
+        let (x_advance, y_advance) = x_y_advances(&props.transform);
         match (
-            (bbox.width() as f32).is_nearly_zero(),
-            (bbox.height() as f32).is_nearly_zero(),
+            ((bbox.width() * x_advance.length()) as f32).is_nearly_zero(),
+            ((bbox.height() * y_advance.length()) as f32).is_nearly_zero(),
         ) {
             (false, false) => {
                 let draw_mode = DrawMode::Fill(fill_rule);

--- a/hayro-interpret/src/interpret/path.rs
+++ b/hayro-interpret/src/interpret/path.rs
@@ -75,9 +75,9 @@ pub(crate) fn fill_path_impl<'a>(
                 path.move_to((bbox.x0, bbox.y0));
                 path.line_to((bbox.x1, bbox.y1));
 
+                let scale = x_advance.length().max(y_advance.length()) as f32;
                 let stroke_props = StrokeProps {
-                    // TODO: Make dependent on transform?
-                    line_width: 0.001,
+                    line_width: if scale > 0.0 { 1.0 / scale } else { 0.001 },
                     line_join: Join::Bevel,
                     line_cap: Cap::Butt,
                     ..Default::default()

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -56,6 +56,14 @@
     "file": "pdfs/custom/color_space_separation_2.pdf"
   },
   {
+    "id": "fill_degenerate_rotated",
+    "file": "pdfs/custom/fill_degenerate_rotated.pdf"
+  },
+  {
+    "id": "fill_degenerate_small_ctm",
+    "file": "pdfs/custom/fill_degenerate_small_ctm.pdf"
+  },
+  {
     "id": "filter_flate_1bit",
     "file": "pdfs/custom/filter_flate_1bit.pdf"
   },

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -56,6 +56,10 @@
     "file": "pdfs/custom/color_space_separation_2.pdf"
   },
   {
+    "id": "fill_degenerate_large_ctm",
+    "file": "pdfs/custom/fill_degenerate_large_ctm.pdf"
+  },
+  {
     "id": "fill_degenerate_rotated",
     "file": "pdfs/custom/fill_degenerate_rotated.pdf"
   },

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -685,6 +685,10 @@
     "file": "pdfs/custom/stream_jpx_6.pdf"
   },
   {
+    "id": "stroke_hairline_large_ctm",
+    "file": "pdfs/custom/stroke_hairline_large_ctm.pdf"
+  },
+  {
     "id": "text_filled_complex_paint",
     "file": "pdfs/custom/text_filled_complex_paint.pdf"
   },

--- a/hayro-tests/pdfs/custom/fill_degenerate_large_ctm.pdf
+++ b/hayro-tests/pdfs/custom/fill_degenerate_large_ctm.pdf
@@ -1,0 +1,40 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 200]/Contents 4 0 R/Resources<</Pattern<</P1 5 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 144>>stream
+0 0 0 rg
+q 4000 0 0 4000 0 0 cm
+0.0025 0.0375 m 0.0725 0.0375 l 0.0725 0.0375 l 0.0025 0.0375 l h f
+Q
+q /Pattern cs /P1 scn 10 20 280 80 re f Q
+
+endstream
+endobj
+5 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 1/BBox[0 0 20 20]/XStep 20/YStep 20/Matrix[2 0 0 2 0 0]/Resources<<>>/Length 43>>stream
+0 0 1 rg 0 10 m 20 10 l 20 10 l 0 10 l h f
+
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000226 00000 n 
+0000000418 00000 n 
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+628
+%%EOF

--- a/hayro-tests/pdfs/custom/fill_degenerate_rotated.pdf
+++ b/hayro-tests/pdfs/custom/fill_degenerate_rotated.pdf
@@ -1,0 +1,32 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 320]/Contents 4 0 R/Resources<<>>>>
+endobj
+4 0 obj
+<</Length 168>>stream
+0 0 0 rg
+q 1 0 0 1 40 40 cm 0 0 m 200 0 l 200 0 l 0 0 l h f Q
+q 1 0 0 1 40 120 cm 0.70710678 0.70710678 -0.70710678 0.70710678 0 0 cm
+0 0 m 200 0 l 200 0 l 0 0 l h f Q
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000205 00000 n 
+trailer
+<</Size 5/Root 1 0 R>>
+startxref
+421
+%%EOF

--- a/hayro-tests/pdfs/custom/fill_degenerate_small_ctm.pdf
+++ b/hayro-tests/pdfs/custom/fill_degenerate_small_ctm.pdf
@@ -1,0 +1,33 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 200]/Contents 4 0 R/Resources<<>>>>
+endobj
+4 0 obj
+<</Length 85>>stream
+0 0 0 rg
+q 0.01 0 0 0.01 0 0 cm
+5000 12000 20000 0.3 re f
+5000 8000 20000 0.6 re f
+Q
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000205 00000 n 
+trailer
+<</Size 5/Root 1 0 R>>
+startxref
+337
+%%EOF

--- a/hayro-tests/pdfs/custom/stroke_hairline_large_ctm.pdf
+++ b/hayro-tests/pdfs/custom/stroke_hairline_large_ctm.pdf
@@ -1,0 +1,59 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 400 300]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>/Pattern<</P1 6 0 R/P2 7 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 545>>stream
+q 4000 0 0 4000 0 0 cm
+0 0 0.8 RG 0.0001 w
+0.0025 0.0025 m 0.0225 0.0025 l 0.0225 0.0225 l 0.0025 0.0225 l h S
+0.8 0 0 RG 0.001 w
+0.0275 0.0025 m 0.0475 0.0025 l 0.0475 0.0225 l 0.0275 0.0225 l h S
+0 0.5 0 RG 0.0001 w
+0.0525 0.0025 m 0.0725 0.0225 l S
+0.0775 0.0025 m 0.0975 0.0025 l 0.0975 0.0225 l 0.0775 0.0225 l h S
+BT 0 g 1 Tr 0.00002 w /F1 0.006 Tf 1 0 0 1 0.0025 0.04 Tm (Ab) Tj ET
+BT 0 g 1 Tr 0.0002 w /F1 0.006 Tf 1 0 0 1 0.0300 0.04 Tm (Cd) Tj ET
+Q
+q /Pattern cs /P1 scn 10 250 380 40 re f Q
+q /Pattern cs /P2 scn 10 200 380 40 re f Q
+
+endstream
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>
+endobj
+6 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 1/BBox[0 0 10 10]/XStep 10/YStep 10/Matrix[2 0 0 2 0 0]/Resources<<>>/Length 64>>stream
+0 0 1 RG 0 w 0 0 m 10 10 l S 0.5 0 0 RG 0.004 w 10 0 m 0 10 l S
+
+endstream
+endobj
+7 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 1/BBox[0 0 10 10]/XStep 10/YStep 10/Matrix[1 0 0 1 0 0]/Resources<<>>/Length 64>>stream
+0 0 1 RG 0 w 0 0 m 10 10 l S 0.5 0 0 RG 0.004 w 10 0 m 0 10 l S
+
+endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000253 00000 n 
+0000000846 00000 n 
+0000000909 00000 n 
+0000001140 00000 n 
+trailer
+<</Size 8/Root 1 0 R>>
+startxref
+1371
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -166,6 +166,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn stream_jpx_3() { run_render_test("stream_jpx_3", "pdfs/custom/stream_jpx_3.pdf", Some("2..=2")); }
 #[test] fn stream_jpx_5() { run_render_test("stream_jpx_5", "pdfs/custom/stream_jpx_5.pdf", None); }
 #[test] fn stream_jpx_6() { run_render_test("stream_jpx_6", "pdfs/custom/stream_jpx_6.pdf", None); }
+#[test] fn stroke_hairline_large_ctm() { run_render_test("stroke_hairline_large_ctm", "pdfs/custom/stroke_hairline_large_ctm.pdf", None); }
 #[test] fn text_filled_complex_paint() { run_render_test("text_filled_complex_paint", "pdfs/custom/text_filled_complex_paint.pdf", None); }
 #[test] fn text_rendering_1() { run_render_test("text_rendering_1", "pdfs/custom/text_rendering_1.pdf", None); }
 #[test] fn text_rendering_2() { run_render_test("text_rendering_2", "pdfs/custom/text_rendering_2.pdf", None); }

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -14,6 +14,8 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn color_space_lab() { run_render_test("color_space_lab", "pdfs/custom/color_space_lab.pdf", None); }
 #[test] fn color_space_separation_1() { run_render_test("color_space_separation_1", "pdfs/custom/color_space_separation_1.pdf", None); }
 #[test] fn color_space_separation_2() { run_render_test("color_space_separation_2", "pdfs/custom/color_space_separation_2.pdf", None); }
+#[test] fn fill_degenerate_rotated() { run_render_test("fill_degenerate_rotated", "pdfs/custom/fill_degenerate_rotated.pdf", None); }
+#[test] fn fill_degenerate_small_ctm() { run_render_test("fill_degenerate_small_ctm", "pdfs/custom/fill_degenerate_small_ctm.pdf", None); }
 #[test] fn filter_flate_1bit() { run_render_test("filter_flate_1bit", "pdfs/custom/filter_flate_1bit.pdf", None); }
 #[test] fn filter_tiff_predictor_gray() { run_render_test("filter_tiff_predictor_gray", "pdfs/custom/filter_tiff_predictor_gray.pdf", None); }
 #[test] fn font_cid_1() { run_render_test("font_cid_1", "pdfs/custom/font_cid_1.pdf", None); }

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -14,6 +14,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn color_space_lab() { run_render_test("color_space_lab", "pdfs/custom/color_space_lab.pdf", None); }
 #[test] fn color_space_separation_1() { run_render_test("color_space_separation_1", "pdfs/custom/color_space_separation_1.pdf", None); }
 #[test] fn color_space_separation_2() { run_render_test("color_space_separation_2", "pdfs/custom/color_space_separation_2.pdf", None); }
+#[test] fn fill_degenerate_large_ctm() { run_render_test("fill_degenerate_large_ctm", "pdfs/custom/fill_degenerate_large_ctm.pdf", None); }
 #[test] fn fill_degenerate_rotated() { run_render_test("fill_degenerate_rotated", "pdfs/custom/fill_degenerate_rotated.pdf", None); }
 #[test] fn fill_degenerate_small_ctm() { run_render_test("fill_degenerate_small_ctm", "pdfs/custom/fill_degenerate_small_ctm.pdf", None); }
 #[test] fn filter_flate_1bit() { run_render_test("filter_flate_1bit", "pdfs/custom/filter_flate_1bit.pdf", None); }

--- a/hayro-tests/tests/svg.rs
+++ b/hayro-tests/tests/svg.rs
@@ -268,3 +268,21 @@ fn issue_typst_7269() {
 fn issue_986() {
     run_svg_test("issue968", "pdfs/custom/issue968.pdf", None);
 }
+
+#[test]
+fn fill_degenerate_rotated() {
+    run_svg_test(
+        "fill_degenerate_rotated",
+        "pdfs/custom/fill_degenerate_rotated.pdf",
+        None,
+    );
+}
+
+#[test]
+fn fill_degenerate_large_ctm() {
+    run_svg_test(
+        "fill_degenerate_large_ctm",
+        "pdfs/custom/fill_degenerate_large_ctm.pdf",
+        None,
+    );
+}

--- a/hayro/src/path.rs
+++ b/hayro/src/path.rs
@@ -10,7 +10,7 @@ impl Renderer<'_> {
         // specification. If we are stroking text, we reduce the threshold as it will otherwise
         // lead to very bold-looking text at low resolutions.
         let min_factor = max_factor(self.ctx.transform());
-        let mut line_width = stroke_props.line_width.max(0.01);
+        let mut line_width = stroke_props.line_width.max(0.01 / min_factor);
         let transformed_width = line_width * min_factor;
 
         // Only enforce line width if not inside of pattern or type 3 glyph.


### PR DESCRIPTION
First of all, thank you very much for your work with this library.

We encountered an issue with a PDF that drew very small shapes with a large (~5k) scale-up. These graphics rendered as completely filled bounding boxes instead of the intended shape (similar to the new `stroke_hairline_large_ctm` test).

This PR groups some fixes related to clamps being applied based on the magnitude of a value in user space rather than device space, leading (apparently) small shapes to be changed or dropped.

These are the visual changes across the corpus for each commit, compared to pdfium (cropped to changed region where appropriate):

<details>
<summary>commit 1 (line width limit)</summary>

`custom/stroke_hairline_large_ctm` (new)  
<img width="1640" height="332" alt="render_custom_stroke_hairline_large_ctm" src="https://github.com/user-attachments/assets/f1d0d48d-0040-457a-ad01-427c9d2c87bb" />

`custom/fill_degenerate_large_ctm` (new)  
<img width="1240" height="232" alt="render_custom_fill_degenerate_large_ctm" src="https://github.com/user-attachments/assets/bad798c6-9d4f-4f04-b99b-4385ed6f2c9c" />

`pdfbox/5447_p0`
<img width="1576" height="312" alt="render_pdfbox_5447_p0_zoom" src="https://github.com/user-attachments/assets/f435d4b0-a865-4c35-9093-639e2832cfaa" />

`pdfbox/4778_p1`
<img width="1448" height="384" alt="render_pdfbox_4778_p1_zoom" src="https://github.com/user-attachments/assets/74ac1210-4180-4c5a-8277-0c30c66c70dd" />

`pdfbox/4938_p1`
<img width="1336" height="232" alt="render_pdfbox_4938_p1_zoom" src="https://github.com/user-attachments/assets/9daab16f-d47c-4f21-93a0-0c3a44aff135" />

`pdfbox/4778_p2`
<img width="1448" height="384" alt="render_pdfbox_4778_p2_zoom" src="https://github.com/user-attachments/assets/a6b227bf-8273-4220-977f-3561583d4460" />

`pdfbox/5464_p0`
<img width="1008" height="440" alt="render_pdfbox_5464_p0_zoom" src="https://github.com/user-attachments/assets/1e64e80f-d005-46a7-92d6-6a0592cedc99" />

`pdfjs/issue16127_p10`
<img width="1448" height="509" alt="render_pdfjs_issue16127_p10_zoom" src="https://github.com/user-attachments/assets/3c1aa141-891a-4d88-ba09-0995e8be1792" />

`pdfbox/3622`
<img width="1540" height="188" alt="render_pdfbox_3622_zoom" src="https://github.com/user-attachments/assets/6a1f1f6a-30de-4051-be11-acb2a2822257" />

`pdfjs/issue16127_p9`
<img width="1608" height="464" alt="render_pdfjs_issue16127_p9_zoom" src="https://github.com/user-attachments/assets/a58a4381-0f88-480b-b6b7-9029066eafe1" />
</details>


<details>
<summary>commit 2 (bbox)</summary>

`pdfbox/5447_p0`  
<img width="1576" height="312" alt="render_pdfbox_5447_p0_zoom" src="https://github.com/user-attachments/assets/7a7f5382-ca94-4452-91d2-231d0776311c" />

`pdfbox/5447_p1`  
<img width="1448" height="384" alt="render_pdfbox_5447_p1_zoom" src="https://github.com/user-attachments/assets/5640ff19-c6ee-4076-a3a3-0f51d8b2ae71" />

`pdfium/414588524_p1`, `pdfium/414588524_p2`, `pdfium/414588524_p3`, `pdfium/414588524_p4` (same header)  
<img width="1400" height="168" alt="render_pdfium_414588524_p1_zoom" src="https://github.com/user-attachments/assets/11e6ca7f-4799-42a3-9152-994b54d2b0c3" />

`custom/fill_degenerate_small_ctm` (new)  
<img width="1240" height="232" alt="render_custom_fill_degenerate_small_ctm" src="https://github.com/user-attachments/assets/00c18293-a09e-4c2e-b66e-91e0e585ed7a" />

`pdfjs/issue16395`  
<img width="1448" height="384" alt="render_pdfjs_issue16395_zoom" src="https://github.com/user-attachments/assets/e569eb68-ce30-4810-b3e9-e5e023912e4d" />

`pdfbox/4938_p1`  
<img width="1336" height="232" alt="render_pdfbox_4938_p1_zoom" src="https://github.com/user-attachments/assets/defd7303-bab7-43ba-bca1-8eab091aaba0" />

`pdfjs/bug1703683`  
<img width="1336" height="228" alt="render_pdfjs_bug1703683_zoom" src="https://github.com/user-attachments/assets/8083c889-3621-48e2-80bd-764ac8e958c9" />

`pdfbox/5952`  
<img width="1368" height="236" alt="render_pdfbox_5952_zoom" src="https://github.com/user-attachments/assets/c79ecb8e-3e2c-4900-be40-23606ab9fdc9" />

`pdfbox/5464_p0`  
<img width="976" height="432" alt="render_pdfbox_5464_p0_zoom" src="https://github.com/user-attachments/assets/8785bedb-c2ee-4668-b9fb-a52c94562d80" />

`pdfbox/3622`  
<img width="1516" height="188" alt="render_pdfbox_3622_zoom" src="https://github.com/user-attachments/assets/1fc2fdfd-31f1-45b3-9074-6feba4f5ec0d" />

</details>

<details>
<summary>commit 3 (fallback stroke width)</summary>

`custom/fill_degenerate_large_ctm` (new)  
<img width="1240" height="232" alt="render_custom_fill_degenerate_large_ctm" src="https://github.com/user-attachments/assets/b681446a-f3dc-42c5-838b-1f9127b5e95c" />

`pdfjs/issue16127_p10`  
<img width="1448" height="384" alt="render_pdfjs_issue16127_p10_zoom" src="https://github.com/user-attachments/assets/5d64434a-e9fb-455a-b58d-5f2849f11a22" />

`pdfjs/issue16127_p9`  
<img width="1160" height="232" alt="render_pdfjs_issue16127_p9_zoom" src="https://github.com/user-attachments/assets/cbe8da31-89ab-4970-a995-61a37665c393" />

`custom/fill_degenerate_large_ctm` (SVG)  
<img width="1240" height="232" alt="svg_custom_fill_degenerate_large_ctm" src="https://github.com/user-attachments/assets/9c732a39-7d21-41f5-a3ca-932d936ef0e8" />

`custom/fill_degenerate_rotated` (SVG)  
<img width="1240" height="352" alt="svg_custom_fill_degenerate_rotated" src="https://github.com/user-attachments/assets/a9c8f431-9ad5-4494-af63-8f54605c2298" />

</details>

Let me know if you'd prefer these as separate PRs.