### PR TITLE
hayro: Apply line width limit post-transform

### DIFF
--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -689,6 +689,10 @@
     "file": "pdfs/custom/stream_jpx_6.pdf"
   },
   {
+    "id": "stroke_hairline_large_ctm",
+    "file": "pdfs/custom/stroke_hairline_large_ctm.pdf"
+  },
+  {
     "id": "text_filled_complex_paint",
     "file": "pdfs/custom/text_filled_complex_paint.pdf"
   },

--- a/hayro-tests/manifest_custom.json
+++ b/hayro-tests/manifest_custom.json
@@ -690,7 +690,8 @@
   },
   {
     "id": "stroke_hairline_large_ctm",
-    "file": "pdfs/custom/stroke_hairline_large_ctm.pdf"
+    "file": "pdfs/custom/stroke_hairline_large_ctm.pdf",
+    "comment": "lines in the tiling patterns are not rendered correctly yet"
   },
   {
     "id": "text_filled_complex_paint",

--- a/hayro-tests/pdfs/custom/stroke_hairline_large_ctm.pdf
+++ b/hayro-tests/pdfs/custom/stroke_hairline_large_ctm.pdf
@@ -1,0 +1,59 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 400 300]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>/Pattern<</P1 6 0 R/P2 7 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 545>>stream
+q 4000 0 0 4000 0 0 cm
+0 0 0.8 RG 0.0001 w
+0.0025 0.0025 m 0.0225 0.0025 l 0.0225 0.0225 l 0.0025 0.0225 l h S
+0.8 0 0 RG 0.001 w
+0.0275 0.0025 m 0.0475 0.0025 l 0.0475 0.0225 l 0.0275 0.0225 l h S
+0 0.5 0 RG 0.0001 w
+0.0525 0.0025 m 0.0725 0.0225 l S
+0.0775 0.0025 m 0.0975 0.0025 l 0.0975 0.0225 l 0.0775 0.0225 l h S
+BT 0 g 1 Tr 0.00002 w /F1 0.006 Tf 1 0 0 1 0.0025 0.04 Tm (Ab) Tj ET
+BT 0 g 1 Tr 0.0002 w /F1 0.006 Tf 1 0 0 1 0.0300 0.04 Tm (Cd) Tj ET
+Q
+q /Pattern cs /P1 scn 10 250 380 40 re f Q
+q /Pattern cs /P2 scn 10 200 380 40 re f Q
+
+endstream
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>
+endobj
+6 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 1/BBox[0 0 10 10]/XStep 10/YStep 10/Matrix[2 0 0 2 0 0]/Resources<<>>/Length 64>>stream
+0 0 1 RG 0 w 0 0 m 10 10 l S 0.5 0 0 RG 0.004 w 10 0 m 0 10 l S
+
+endstream
+endobj
+7 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 1/BBox[0 0 10 10]/XStep 10/YStep 10/Matrix[1 0 0 1 0 0]/Resources<<>>/Length 64>>stream
+0 0 1 RG 0 w 0 0 m 10 10 l S 0.5 0 0 RG 0.004 w 10 0 m 0 10 l S
+
+endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000253 00000 n 
+0000000846 00000 n 
+0000000909 00000 n 
+0000001140 00000 n 
+trailer
+<</Size 8/Root 1 0 R>>
+startxref
+1371
+%%EOF

--- a/hayro-tests/tests/render.rs
+++ b/hayro-tests/tests/render.rs
@@ -167,6 +167,7 @@ use crate::{run_render_test, run_render_test_with_password};
 #[test] fn stream_jpx_3() { run_render_test("stream_jpx_3", "pdfs/custom/stream_jpx_3.pdf", Some("2..=2")); }
 #[test] fn stream_jpx_5() { run_render_test("stream_jpx_5", "pdfs/custom/stream_jpx_5.pdf", None); }
 #[test] fn stream_jpx_6() { run_render_test("stream_jpx_6", "pdfs/custom/stream_jpx_6.pdf", None); }
+#[test] fn stroke_hairline_large_ctm() { run_render_test("stroke_hairline_large_ctm", "pdfs/custom/stroke_hairline_large_ctm.pdf", None); }
 #[test] fn text_filled_complex_paint() { run_render_test("text_filled_complex_paint", "pdfs/custom/text_filled_complex_paint.pdf", None); }
 #[test] fn text_rendering_1() { run_render_test("text_rendering_1", "pdfs/custom/text_rendering_1.pdf", None); }
 #[test] fn text_rendering_2() { run_render_test("text_rendering_2", "pdfs/custom/text_rendering_2.pdf", None); }

--- a/hayro/src/path.rs
+++ b/hayro/src/path.rs
@@ -10,7 +10,7 @@ impl Renderer<'_> {
         // specification. If we are stroking text, we reduce the threshold as it will otherwise
         // lead to very bold-looking text at low resolutions.
         let min_factor = max_factor(self.ctx.transform());
-        let mut line_width = stroke_props.line_width.max(0.01);
+        let mut line_width = stroke_props.line_width.max(0.01 / min_factor);
         let transformed_width = line_width * min_factor;
 
         // Only enforce line width if not inside of pattern or type 3 glyph.


### PR DESCRIPTION
Split from #1348, line width minimum only.

<details>
<summary>visual changes to corpus</summary>

`custom/stroke_hairline_large_ctm` (new)  
<img width="1640" height="332" alt="render_custom_stroke_hairline_large_ctm" src="https://github.com/user-attachments/assets/f1d0d48d-0040-457a-ad01-427c9d2c87bb" />

`custom/fill_degenerate_large_ctm` (new)  
<img width="1240" height="232" alt="render_custom_fill_degenerate_large_ctm" src="https://github.com/user-attachments/assets/bad798c6-9d4f-4f04-b99b-4385ed6f2c9c" />

`pdfbox/5447_p0`
<img width="1576" height="312" alt="render_pdfbox_5447_p0_zoom" src="https://github.com/user-attachments/assets/f435d4b0-a865-4c35-9093-639e2832cfaa" />

`pdfbox/4778_p1`
<img width="1448" height="384" alt="render_pdfbox_4778_p1_zoom" src="https://github.com/user-attachments/assets/74ac1210-4180-4c5a-8277-0c30c66c70dd" />

`pdfbox/4938_p1`
<img width="1336" height="232" alt="render_pdfbox_4938_p1_zoom" src="https://github.com/user-attachments/assets/9daab16f-d47c-4f21-93a0-0c3a44aff135" />

`pdfbox/4778_p2`
<img width="1448" height="384" alt="render_pdfbox_4778_p2_zoom" src="https://github.com/user-attachments/assets/a6b227bf-8273-4220-977f-3561583d4460" />

`pdfbox/5464_p0`
<img width="1008" height="440" alt="render_pdfbox_5464_p0_zoom" src="https://github.com/user-attachments/assets/1e64e80f-d005-46a7-92d6-6a0592cedc99" />

`pdfjs/issue16127_p10`
<img width="1448" height="509" alt="render_pdfjs_issue16127_p10_zoom" src="https://github.com/user-attachments/assets/3c1aa141-891a-4d88-ba09-0995e8be1792" />

`pdfbox/3622`
<img width="1540" height="188" alt="render_pdfbox_3622_zoom" src="https://github.com/user-attachments/assets/6a1f1f6a-30de-4051-be11-acb2a2822257" />

`pdfjs/issue16127_p9`
<img width="1608" height="464" alt="render_pdfjs_issue16127_p9_zoom" src="https://github.com/user-attachments/assets/a58a4381-0f88-480b-b6b7-9029066eafe1" />
</details>