### PR TITLE
hayro-jpeg2000: Size the coefficient buffer by the resolution asked for

### DIFF
--- a/hayro-jpeg2000/src/j2c/build.rs
+++ b/hayro-jpeg2000/src/j2c/build.rs
@@ -3,7 +3,7 @@
 use super::decode::{DecompositionStorage, TileDecompositions};
 use super::rect::IntRect;
 use super::tag_tree::TagTree;
-use super::tile::{ComponentTile, ResolutionTile, Tile};
+use super::tile::{ResolutionTile, Tile};
 use crate::error::{DecodingError, Result, ValidationError};
 use alloc::vec;
 use core::iter;
@@ -11,30 +11,12 @@ use core::ops::Range;
 
 /// Build and allocate all necessary structures to process the code-blocks
 /// for a specific tile. Also parses the segments for each code-block.
-///
-/// `skipped_resolution_levels` is how many of the highest resolution levels the
-/// decoder was asked to leave out (see `DecodeSettings::target_resolution`).
-/// Their packets are still described here, because a packet header is what says
-/// how long its body is and the packets of a tile-part are read in sequence — but
-/// their coefficients are never decoded, so no storage is reserved for them.
 pub(crate) fn build(
     tile: &Tile<'_>,
     storage: &mut DecompositionStorage<'_>,
     skipped_resolution_levels: u8,
 ) -> Result<()> {
     build_decompositions(tile, storage, skipped_resolution_levels)
-}
-
-/// The number of resolution levels of `component_tile` that will be decoded.
-///
-/// At least one: the number of levels skipped is clamped, where it is read, to one
-/// below the smallest count any component of the image has.
-fn decoded_resolution_levels(component_tile: &ComponentTile<'_>, skipped: u8) -> u8 {
-    component_tile
-        .component_info
-        .num_resolution_levels()
-        .saturating_sub(skipped)
-        .max(1)
 }
 
 fn build_decompositions(
@@ -45,18 +27,11 @@ fn build_decompositions(
     let mut total_coefficients = 0_usize;
 
     for component_tile in tile.component_tiles() {
-        // The sub-bands of resolution levels 0 to r partition the rectangle of
-        // resolution level r (B-15), so the highest level that will be decoded
-        // states exactly how many coefficients the sub-bands below it need. With
-        // nothing skipped that is the component tile's own rectangle, which is what
-        // this used to be unconditionally — and a decode asked to stop early still
-        // allocated the full-resolution image.
-        let top = ResolutionTile::new(
-            component_tile,
-            decoded_resolution_levels(&component_tile, skipped_resolution_levels) - 1,
-        );
-        let component_samples =
-            usize::try_from(top.rect.area()).map_err(|_| ValidationError::ImageTooLarge)?;
+        let decoded_resolutions =
+            component_tile.component_info.num_resolution_levels() - skipped_resolution_levels;
+        let top_resolution = ResolutionTile::new(component_tile, decoded_resolutions - 1);
+        let component_samples = usize::try_from(top_resolution.rect.area())
+            .map_err(|_| ValidationError::ImageTooLarge)?;
         total_coefficients = total_coefficients
             .checked_add(component_samples)
             .ok_or(ValidationError::ImageTooLarge)?;
@@ -72,7 +47,7 @@ fn build_decompositions(
 
     for (component_idx, component_tile) in tile.component_tiles().enumerate() {
         let decoded_resolutions =
-            decoded_resolution_levels(&component_tile, skipped_resolution_levels);
+            component_tile.component_info.num_resolution_levels() - skipped_resolution_levels;
         let d_start = storage.decompositions.len();
         let mut resolution_tiles = component_tile.resolution_tiles();
 
@@ -100,9 +75,7 @@ fn build_decompositions(
 
             let precincts = build_precincts(resolution_tile, sub_band_rect, tile, storage)?;
 
-            // A resolution level that will not be decoded gets an empty range: its
-            // code-blocks are still walked so that the packets can be read past, but
-            // nothing ever writes a coefficient of it.
+            // No need to allocate coefficients for skipped resolution levels.
             let added_coefficients = if resolution_tile.resolution < decoded_resolutions {
                 usize::try_from(sub_band_rect.area()).map_err(|_| ValidationError::ImageTooLarge)?
             } else {

--- a/hayro-jpeg2000/src/j2c/build.rs
+++ b/hayro-jpeg2000/src/j2c/build.rs
@@ -3,7 +3,7 @@
 use super::decode::{DecompositionStorage, TileDecompositions};
 use super::rect::IntRect;
 use super::tag_tree::TagTree;
-use super::tile::{ResolutionTile, Tile};
+use super::tile::{ComponentTile, ResolutionTile, Tile};
 use crate::error::{DecodingError, Result, ValidationError};
 use alloc::vec;
 use core::iter;
@@ -11,16 +11,52 @@ use core::ops::Range;
 
 /// Build and allocate all necessary structures to process the code-blocks
 /// for a specific tile. Also parses the segments for each code-block.
-pub(crate) fn build(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>) -> Result<()> {
-    build_decompositions(tile, storage)
+///
+/// `skipped_resolution_levels` is how many of the highest resolution levels the
+/// decoder was asked to leave out (see `DecodeSettings::target_resolution`).
+/// Their packets are still described here, because a packet header is what says
+/// how long its body is and the packets of a tile-part are read in sequence — but
+/// their coefficients are never decoded, so no storage is reserved for them.
+pub(crate) fn build(
+    tile: &Tile<'_>,
+    storage: &mut DecompositionStorage<'_>,
+    skipped_resolution_levels: u8,
+) -> Result<()> {
+    build_decompositions(tile, storage, skipped_resolution_levels)
 }
 
-fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>) -> Result<()> {
+/// The number of resolution levels of `component_tile` that will be decoded.
+///
+/// At least one: the number of levels skipped is clamped, where it is read, to one
+/// below the smallest count any component of the image has.
+fn decoded_resolution_levels(component_tile: &ComponentTile<'_>, skipped: u8) -> u8 {
+    component_tile
+        .component_info
+        .num_resolution_levels()
+        .saturating_sub(skipped)
+        .max(1)
+}
+
+fn build_decompositions(
+    tile: &Tile<'_>,
+    storage: &mut DecompositionStorage<'_>,
+    skipped_resolution_levels: u8,
+) -> Result<()> {
     let mut total_coefficients = 0_usize;
 
     for component_tile in tile.component_tiles() {
-        let component_samples = usize::try_from(component_tile.rect.area())
-            .map_err(|_| ValidationError::ImageTooLarge)?;
+        // The sub-bands of resolution levels 0 to r partition the rectangle of
+        // resolution level r (B-15), so the highest level that will be decoded
+        // states exactly how many coefficients the sub-bands below it need. With
+        // nothing skipped that is the component tile's own rectangle, which is what
+        // this used to be unconditionally — and a decode asked to stop early still
+        // allocated the full-resolution image.
+        let top = ResolutionTile::new(
+            component_tile,
+            decoded_resolution_levels(&component_tile, skipped_resolution_levels) - 1,
+        );
+        let component_samples =
+            usize::try_from(top.rect.area()).map_err(|_| ValidationError::ImageTooLarge)?;
         total_coefficients = total_coefficients
             .checked_add(component_samples)
             .ok_or(ValidationError::ImageTooLarge)?;
@@ -35,6 +71,8 @@ fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>)
     let mut coefficient_counter = 0_usize;
 
     for (component_idx, component_tile) in tile.component_tiles().enumerate() {
+        let decoded_resolutions =
+            decoded_resolution_levels(&component_tile, skipped_resolution_levels);
         let d_start = storage.decompositions.len();
         let mut resolution_tiles = component_tile.resolution_tiles();
 
@@ -62,8 +100,14 @@ fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>)
 
             let precincts = build_precincts(resolution_tile, sub_band_rect, tile, storage)?;
 
-            let added_coefficients = usize::try_from(sub_band_rect.area())
-                .map_err(|_| ValidationError::ImageTooLarge)?;
+            // A resolution level that will not be decoded gets an empty range: its
+            // code-blocks are still walked so that the packets can be read past, but
+            // nothing ever writes a coefficient of it.
+            let added_coefficients = if resolution_tile.resolution < decoded_resolutions {
+                usize::try_from(sub_band_rect.area()).map_err(|_| ValidationError::ImageTooLarge)?
+            } else {
+                0
+            };
             let next_coefficient_counter = coefficient_counter
                 .checked_add(added_coefficients)
                 .ok_or(ValidationError::ImageTooLarge)?;

--- a/hayro-jpeg2000/src/j2c/decode.rs
+++ b/hayro-jpeg2000/src/j2c/decode.rs
@@ -143,7 +143,7 @@ fn decode_tile<'a, 'b>(
 
     // First, we build the decompositions, including their sub-bands, precincts
     // and code blocks.
-    build::build(tile, storage)?;
+    build::build(tile, storage, header.skipped_resolution_levels)?;
     // Next, we parse the layers/segments for each code block.
     segment::parse(tile, progression_iterator, header, storage)?;
     // We then decode the bitplanes of each code block, yielding the


### PR DESCRIPTION
A decode given `DecodeSettings::target_resolution` skips the highest resolution levels: their bit-planes are not decoded (decode.rs) and their decompositions are not synthesised (idwt.rs). `build_decompositions` still reserved a coefficient for every sample of the *full*-resolution image, because it sized `storage.coefficients` from the component tile's own rectangle.

So a reduced decode bought time and no memory. On a 12608x16806 four-channel image asked for at 788x1051 -- five levels down, 1/256th of the samples -- the buffer was still one allocation of 3 390 240 768 bytes.

The sub-bands of resolution levels 0..=r partition the rectangle of resolution level r (B-15), so the highest level that will be decoded states exactly what the levels below it need; the levels above it get an empty range. Their code-blocks are still built, because a packet header is what says how long its body is and a tile-part's packets are read in sequence -- in LRCP order the packets of the skipped levels are interleaved with the ones that are kept, so they have to be read past rather than ignored. `build_decompositions`'s existing assertion that the counter meets the buffer length is what checks the partition.

Measured on that image, peak address space (VmPeak), decoding through `Image::decode`:

  target      before      after
  788x1051    3336 MB     115 MB
  1576x2101   3424 MB     241 MB
  3152x4202   3775 MB     743 MB
  6304x8403   5176 MB    2751 MB

Resident size does not move -- the buffer was calloc'd and its pages were never touched -- which is exactly why this had gone unnoticed. What it costs is address space, and that is what an `RLIMIT_AS` sandbox, a 32-bit target and a no_std allocator with a fixed arena all bound: under a 1 GiB `RLIMIT_AS` none of the four decodes above completed before this change and all four complete after it.

Nothing changes at full resolution, where the highest kept level is the component tile. Output is unchanged: all 183 assets of the test suite are byte-identical to snapshots taken before the change, and the Annex B.4 worked example still passes.