### PR TITLE
Honor ImageDecodeParams::target_dimension for DCTDecode and all other image filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "hayro-ccitt",
  "hayro-jbig2",
  "hayro-jpeg2000",
+ "jpeg-decoder",
  "log",
  "md5",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ sitro = { git = "https://github.com/LaurenzV/sitro", rev="fb804b3" }
 xmlwriter = { version = "0.1" }
 base64 = { version = "0.22" }
 zune-jpeg = { version = "0.5", default-features = false }
+jpeg-decoder = { version = "0.3", default-features = false, features = ["platform_independent"] }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "dc23e93841d20060743e490ef49c1e0d0d22cf40", default-features = false, features = ["std", "png", "u8_pipeline"] }
 pic-scale = { version = "0.7.9", default-features = false }
 fearless_simd = "0.6.0"

--- a/hayro-interpret/src/x_object/decode/image.rs
+++ b/hayro-interpret/src/x_object/decode/image.rs
@@ -1,5 +1,8 @@
 use super::mask::decode_mask;
-use super::{DecodeContext, decode_context, decode_u8_samples, fix_image_length, unpack_samples};
+use super::{
+    DecodeContext, decode_context, decode_u8_samples, downsample_image_data, downsample_luma,
+    fix_image_length, unpack_samples,
+};
 use crate::color::{ColorComponents, ToLuma, ToRgb};
 use crate::interpret::state::ActiveTransferFunction;
 use crate::x_object::image::ImageXObject;
@@ -44,7 +47,28 @@ impl<'a, 'b> ImageDecoder<'a, 'b> {
 
     fn decode(mut self) -> Option<DecodedImage> {
         let mut image = self.decode_image()?;
-        let alpha = self.decode_alpha(&mut image);
+        let mut alpha = self.decode_alpha(&mut image);
+
+        // Downsample the final color data and, independently, its optional
+        // alpha channel toward the target-dimension hint. This complements
+        // the syntax-level scaled decode some filters already do (DCT, JPX):
+        // it applies uniformly, after decoding, regardless of which filter
+        // produced `image`/`alpha`, catching every filter that doesn't have
+        // its own scaled-decode path. `alpha` was resolved above via the
+        // untouched, native-resolution `decode_mask`/`resolve_matte` path,
+        // so it can carry different native dimensions than `image` (an
+        // SMask/Mask needn't match its image's size) -- reconstruct its own
+        // dict-space dimensions from its still-native `scale_factors` rather
+        // than reaching back into the mask's own `ImageXObject`.
+        if let Some(t) = self.target_dimension {
+            downsample_image_data(&mut image, self.obj.width, self.obj.height, t);
+
+            if let Some(a) = &mut alpha {
+                let dict_w = ((a.width as f32 * a.scale_factors.0).round() as u32).max(1);
+                let dict_h = ((a.height as f32 * a.scale_factors.1).round() as u32).max(1);
+                downsample_luma(a, dict_w, dict_h, t);
+            }
+        }
 
         Some(DecodedImage { image, alpha })
     }

--- a/hayro-interpret/src/x_object/decode/mod.rs
+++ b/hayro-interpret/src/x_object/decode/mod.rs
@@ -8,6 +8,7 @@ use crate::InterpreterWarning;
 use crate::color::ColorSpace;
 use crate::function::interpolate;
 use crate::x_object::image::{ImageKind, ImageXObject};
+use crate::{ImageData, LumaData};
 use hayro_syntax::bit_reader::BitReader;
 use hayro_syntax::object::Array;
 use hayro_syntax::object::dict::keys::*;
@@ -109,6 +110,122 @@ fn decode_context<'a>(
         bits_per_component,
         decode_arr,
     })
+}
+
+/// Integer box-filter downsample, in place. Only acts (reallocating `data`)
+/// when the image is at least 2x `target` in both dimensions; otherwise a
+/// no-op -- no reallocation, `width`/`height`/`data` left untouched.
+/// `num_components` is 3 for RGB, 1 for luma/alpha.
+///
+/// Averages each `k`x`k` window per channel, dividing by the actual sample
+/// count in that window (partial windows at the right/bottom edges when `k`
+/// doesn't evenly divide the source dimensions).
+pub(crate) fn downsample_to_target(
+    data: &mut Vec<u8>,
+    num_components: usize,
+    width: &mut u32,
+    height: &mut u32,
+    target: (u32, u32),
+) {
+    let (tw, th) = target;
+    let (w, h) = (*width, *height);
+
+    if w == 0 || h == 0 || num_components == 0 {
+        return;
+    }
+
+    let k = (w / (2 * tw.max(1))).min(h / (2 * th.max(1)));
+
+    if k < 2 {
+        return;
+    }
+
+    let new_w = w.div_ceil(k);
+    let new_h = h.div_ceil(k);
+
+    let mut out = vec![0_u8; new_w as usize * new_h as usize * num_components];
+    // `num_components` is always 1 or 3 here (luma or RGB); 4 gives headroom.
+    let mut sums = [0_u64; 4];
+
+    for oy in 0..new_h {
+        let y0 = oy * k;
+        let y1 = (y0 + k).min(h);
+
+        for ox in 0..new_w {
+            let x0 = ox * k;
+            let x1 = (x0 + k).min(w);
+
+            let count = u64::from(y1 - y0) * u64::from(x1 - x0);
+            if count == 0 {
+                continue;
+            }
+
+            sums[..num_components].fill(0);
+
+            for y in y0..y1 {
+                let row_base = y as usize * w as usize * num_components;
+
+                for x in x0..x1 {
+                    let px_base = row_base + x as usize * num_components;
+
+                    for (c, sum) in sums.iter_mut().enumerate().take(num_components) {
+                        *sum += u64::from(data[px_base + c]);
+                    }
+                }
+            }
+
+            let out_base = (oy as usize * new_w as usize + ox as usize) * num_components;
+            for (c, sum) in sums.iter().enumerate().take(num_components) {
+                out[out_base + c] = (*sum / count) as u8;
+            }
+        }
+    }
+
+    *data = out;
+    *width = new_w;
+    *height = new_h;
+}
+
+/// Downsample a final `ImageData` (post color-space conversion, so this
+/// works uniformly regardless of which syntax-level filter produced it)
+/// toward `target`, recomputing `scale_factors` as `dict_dim / new_dim` --
+/// the same invariant `decode_context` establishes above (`scale_x =
+/// obj.width as f32 / d.width as f32`), just re-derived against the shrunk
+/// dimensions instead of the originally-decoded ones.
+pub(crate) fn downsample_image_data(
+    image: &mut ImageData,
+    dict_w: u32,
+    dict_h: u32,
+    target: (u32, u32),
+) {
+    match image {
+        ImageData::Rgb(d) => {
+            downsample_to_target(&mut d.data, 3, &mut d.width, &mut d.height, target);
+            d.scale_factors = (
+                dict_w as f32 / d.width as f32,
+                dict_h as f32 / d.height as f32,
+            );
+        }
+        ImageData::Luma(d) => {
+            downsample_to_target(&mut d.data, 1, &mut d.width, &mut d.height, target);
+            d.scale_factors = (
+                dict_w as f32 / d.width as f32,
+                dict_h as f32 / d.height as f32,
+            );
+        }
+    }
+}
+
+/// Same treatment as `downsample_image_data`, for a standalone alpha/
+/// stencil-mask `LumaData`. `dict_w`/`dict_h` are the mask's own dict
+/// dimensions (which can differ from the color image it accompanies) --
+/// callers derive them from whichever `ImageXObject` decoded this luma.
+pub(crate) fn downsample_luma(luma: &mut LumaData, dict_w: u32, dict_h: u32, target: (u32, u32)) {
+    downsample_to_target(&mut luma.data, 1, &mut luma.width, &mut luma.height, target);
+    luma.scale_factors = (
+        dict_w as f32 / luma.width as f32,
+        dict_h as f32 / luma.height as f32,
+    );
 }
 
 #[must_use]

--- a/hayro-interpret/src/x_object/image.rs
+++ b/hayro-interpret/src/x_object/image.rs
@@ -1,4 +1,4 @@
-use super::decode::{DecodedImage, DecodedMask, decode_image, decode_mask};
+use super::decode::{DecodedImage, DecodedMask, decode_image, decode_mask, downsample_luma};
 use super::xobject_oc;
 use crate::WarningSinkFn;
 use crate::cache::Cache;
@@ -203,7 +203,20 @@ impl<'a> ImageXObject<'a> {
             return None;
         }
 
-        decode_mask(self, target_dimension)
+        let mut decoded = decode_mask(self, target_dimension)?;
+
+        // Downsample the top-level stencil/`ImageMask` luma toward the
+        // hint. This is the only external call site for a genuine stencil
+        // mask (painted directly, not as another image's SMask/Mask) --
+        // `resolve_alpha`/`resolve_matte` in `decode::image` call
+        // `decode_mask` directly and are unaffected, so their internally
+        // resolved alpha stays native until `ImageDecoder::decode` performs
+        // its own downsample pass at the end.
+        if let Some(t) = target_dimension {
+            downsample_luma(&mut decoded.luma, self.width, self.height, t);
+        }
+
+        Some(decoded)
     }
 
     pub(crate) fn decoded_image(

--- a/hayro-syntax/Cargo.toml
+++ b/hayro-syntax/Cargo.toml
@@ -10,9 +10,14 @@ license = { workspace = true }
 readme = "README.md"
 
 [features]
-default = ["std", "images"]
+default = ["std", "images", "jpeg-decoder"]
 std = ["hayro-jbig2?/std", "hayro-jpeg2000?/std", "dep:rustc-hash", "zune-jpeg?/std"]
 images = ["dep:zune-jpeg", "dep:hayro-ccitt", "dep:hayro-jbig2", "dep:hayro-jpeg2000"]
+# Use `jpeg-decoder`'s IDCT-scaled decoding to satisfy a DCTDecode image's
+# `ImageDecodeParams::target_dimension` hint directly during decode (falling
+# back to the regular `images` decode path otherwise). Requires `std`, since
+# `jpeg-decoder` decodes from `std::io::Read` unconditionally.
+jpeg-decoder = ["dep:jpeg-decoder", "std"]
 unsafe = [
     "std",
     "dep:flate2",
@@ -35,6 +40,7 @@ zune-jpeg = { workspace = true, optional = true }
 hayro-ccitt = { workspace = true, optional = true }
 hayro-jbig2 = { workspace = true, optional = true }
 hayro-jpeg2000 = { workspace = true, optional = true }
+jpeg-decoder = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/hayro-syntax/src/filter/dct.rs
+++ b/hayro-syntax/src/filter/dct.rs
@@ -24,6 +24,11 @@ pub(crate) fn decode(
     // are too large (if they are too small, they will just be padded later on).
     let data = maybe_patch_jpeg_dimensions(data, image_params)?;
 
+    #[cfg(feature = "jpeg-decoder")]
+    if let Some(scaled) = try_scaled_decode(&data, params, image_params) {
+        return Some(scaled);
+    }
+
     let options = DecoderOptions::default()
         .set_max_width(u16::MAX as usize)
         .set_max_height(u16::MAX as usize);
@@ -94,6 +99,83 @@ pub(crate) fn decode(
 
     Some(FilterResult {
         data: Cow::Owned(decoded),
+        image_data: Some(image_data),
+    })
+}
+
+/// Attempt an IDCT-scaled decode via `jpeg-decoder`, honoring
+/// `image_params.target_dimension`, to avoid paying full-resolution decode
+/// time and memory for an image that the renderer will only ever composite
+/// at a much smaller size.
+///
+/// Returns `None` (never a wrong answer) on any error or unmet
+/// precondition; the caller then falls through to the existing
+/// full-resolution `zune-jpeg` path.
+#[cfg(feature = "jpeg-decoder")]
+fn try_scaled_decode(
+    data: &[u8],
+    params: &Dict<'_>,
+    image_params: &ImageDecodeParams,
+) -> Option<FilterResult<'static>> {
+    let (target_w, target_h) = image_params.target_dimension?;
+    if target_w < 1 || target_h < 1 {
+        return None;
+    }
+
+    // `jpeg_decoder::Decoder::scale` takes `u16` dimensions; bail (rather
+    // than truncate) if the hint is somehow outside that range.
+    if target_w > u16::MAX as u32 || target_h > u16::MAX as u32 {
+        return None;
+    }
+
+    // Conservative: only bother if we can at least halve both dimensions.
+    // Safe from overflow: both operands are bounded by u16::MAX above.
+    if image_params.width < 2 * target_w || image_params.height < 2 * target_h {
+        return None;
+    }
+
+    // `jpeg-decoder` doesn't apply a PDF /DecodeParms ColorTransform
+    // override; skip when one is present rather than risk diverging from
+    // zune-jpeg's color handling.
+    if params.get::<u8>(COLOR_TRANSFORM).is_some() {
+        return None;
+    }
+
+    // The `MultiBand` override path (num_components outside 1/3, e.g. spot
+    // colors) isn't handled by the scaled decoder; fall through for those.
+    if let Some(n) = image_params.num_components
+        && !matches!(n, 1 | 3)
+    {
+        return None;
+    }
+
+    let mut decoder = jpeg_decoder::Decoder::new(std::io::Cursor::new(data));
+    decoder.read_info().ok()?;
+    let info = decoder.info()?;
+
+    // Only the dominant scanned-document cases: grayscale and YCbCr/RGB.
+    // CMYK32 and L16 fall through to zune-jpeg.
+    let color_space = match info.pixel_format {
+        jpeg_decoder::PixelFormat::L8 => ImageColorSpace::Gray,
+        jpeg_decoder::PixelFormat::RGB24 => ImageColorSpace::Rgb,
+        _ => return None,
+    };
+
+    let req_w = target_w.min(u16::MAX as u32) as u16;
+    let req_h = target_h.min(u16::MAX as u32) as u16;
+    let (actual_w, actual_h) = decoder.scale(req_w, req_h).ok()?;
+    let pixels = decoder.decode().ok()?;
+
+    let image_data = ImageData {
+        alpha: None,
+        color_space: Some(color_space),
+        bits_per_component: 8,
+        width: actual_w as u32,
+        height: actual_h as u32,
+    };
+
+    Some(FilterResult {
+        data: Cow::Owned(pixels),
         image_data: Some(image_data),
     })
 }


### PR DESCRIPTION
`ImageDecodeParams::target_dimension` is already computed by the renderer from the real draw transform and threaded into every image decode (`hayro/src/image.rs::draw_pdf_image` → `with_rgba`/`with_stencil`), documented as a best-effort size hint — but today only `filter/jpx.rs` (JPEG 2000) actually uses it. Every other filter, including the very common DCTDecode (JPEG), always decodes at native resolution even when the renderer is about to draw the image at a small fraction of that size.

This is a real cost for scanned/print-quality documents: PDFs commonly embed images 2–10x larger than their on-page footprint. Two changes close that gap:

1. **hayro-syntax**: DCTDecode gets a true scaled decode via `jpeg-decoder`'s IDCT downscaling (`Decoder::scale`, powers of two down to 1/8) whenever the hint implies at least a 2x reduction on both axes and the image is a plain grayscale/YCbCr/RGB JPEG with no ColorTransform override. Gated behind a new `jpeg-decoder` feature (default on, requires `std`, follows the existing optional-dep-that-forces-`std` pattern), rayon explicitly disabled.
2. **hayro-interpret**: every other filter's fully-decoded output (color + alpha, and top-level stencil/ImageMask luma) is downsampled toward the hint with an integer box filter when it is >=2x oversampled, recomputing `scale_factors` so compositing is unaffected. A no-op below 2x — no reallocation.

Together these bound an image's decode-time memory to roughly 2x its drawn size instead of its native size, regardless of filter. Measured on an 11 MB, 291-page consumer manual rendered at ~440px width on an embedded consumer device: worst-page peak RSS 73 MB → 50 MB; peak RSS over a 30-page sequential-render session 300+ MB (still climbing) → a ~196 MB plateau.

Both changes fail closed: any unmet precondition or decode error falls straight through to the existing full-resolution path, so images that don't hit the fast path decode byte-for-byte as before. Verified: workspace `clippy -D warnings`/`fmt`/`doc` clean on the CI-pinned 1.92.0 toolchain, all 51 per-feature `cargo hack` checks pass, no_std + `images` (without `std`) still builds on `thumbv6m-none-eabi`, and `rayon` stays out of the dependency graph.

One caveat worth a maintainer look: 6 of the local snapshot tests in `hayro-tests` (`filter_flate_1bit`, `image_ccit_3`, `image_ccit_4`, `image_inline_2`, `image_inline_3`, `image_jbig2_crash`) change output under this patch. In every case the test PDF embeds its image at 2–12x its on-page draw size — exactly the condition the new box filter targets — and it fires in ordinary `render_pdf(pdf, 1.0, ...)` rendering too, since the renderer always passes a real (non-`None`) target hint. I inspected the diff images directly: sub-pixel antialiasing differences from a two-stage resample, visually indistinguishable, no artifacts — but a real, by-design departure from bit-exactness for oversampled embeds, so I have not regenerated the references. Happy to gate the interpret-level filter behind an `InterpreterSettings` flag (default off) instead, if you'd rather keep default rendering bit-exact — the syntax-level DCT change is already independently feature-gated.
