### PR TITLE
hayro-jpeg2000: Lift hardcoded restriction on image dimensions

### DIFF
--- a/hayro-jpeg2000/src/j2c/build.rs
+++ b/hayro-jpeg2000/src/j2c/build.rs
@@ -4,7 +4,7 @@ use super::decode::{DecompositionStorage, TileDecompositions};
 use super::rect::IntRect;
 use super::tag_tree::TagTree;
 use super::tile::{ResolutionTile, Tile};
-use crate::error::{DecodingError, Result};
+use crate::error::{DecodingError, Result, ValidationError};
 use alloc::vec;
 use core::iter;
 use core::ops::Range;
@@ -16,11 +16,14 @@ pub(crate) fn build(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>) -> 
 }
 
 fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>) -> Result<()> {
-    let mut total_coefficients = 0;
+    let mut total_coefficients = 0_usize;
 
     for component_tile in tile.component_tiles() {
-        total_coefficients +=
-            component_tile.rect.width() as usize * component_tile.rect.height() as usize;
+        let component_samples = usize::try_from(component_tile.rect.area())
+            .map_err(|_| ValidationError::ImageTooLarge)?;
+        total_coefficients = total_coefficients
+            .checked_add(component_samples)
+            .ok_or(ValidationError::ImageTooLarge)?;
     }
 
     if storage.coefficients.is_empty() {
@@ -29,7 +32,7 @@ fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>)
     } else {
         storage.coefficients.resize(total_coefficients, 0.0);
     }
-    let mut coefficient_counter = 0;
+    let mut coefficient_counter = 0_usize;
 
     for (component_idx, component_tile) in tile.component_tiles().enumerate() {
         let d_start = storage.decompositions.len();
@@ -59,9 +62,13 @@ fn build_decompositions(tile: &Tile<'_>, storage: &mut DecompositionStorage<'_>)
 
             let precincts = build_precincts(resolution_tile, sub_band_rect, tile, storage)?;
 
-            let added_coefficients = (sub_band_rect.width() * sub_band_rect.height()) as usize;
-            let coefficients = coefficient_counter..(coefficient_counter + added_coefficients);
-            coefficient_counter += added_coefficients;
+            let added_coefficients = usize::try_from(sub_band_rect.area())
+                .map_err(|_| ValidationError::ImageTooLarge)?;
+            let next_coefficient_counter = coefficient_counter
+                .checked_add(added_coefficients)
+                .ok_or(ValidationError::ImageTooLarge)?;
+            let coefficients = coefficient_counter..next_coefficient_counter;
+            coefficient_counter = next_coefficient_counter;
 
             let idx = storage.sub_bands.len();
             storage.sub_bands.push(SubBand {

--- a/hayro-jpeg2000/src/j2c/codestream.rs
+++ b/hayro-jpeg2000/src/j2c/codestream.rs
@@ -44,6 +44,7 @@ pub(crate) fn read_header<'a>(
     }
 
     let mut size_data = size_marker(reader)?;
+    size_data.num_tiles()?;
 
     let mut cod = None;
     let mut qcd = None;
@@ -503,20 +504,29 @@ impl SizeData {
     }
 
     /// The total number of tiles.
-    pub(crate) fn num_tiles(&self) -> u32 {
-        self.num_x_tiles() * self.num_y_tiles()
+    pub(crate) fn num_tiles(&self) -> Result<u32> {
+        let tile_count = self
+            .num_x_tiles()
+            .checked_mul(self.num_y_tiles())
+            .ok_or(ValidationError::ImageTooLarge)?;
+
+        Ok(tile_count)
     }
 
     /// Return the overall width of the image.
     pub(crate) fn image_width(&self) -> u32 {
-        (self.reference_grid_width - self.image_area_x_offset)
-            .div_ceil(self.x_shrink_factor * self.x_resolution_shrink_factor)
+        let divisor = u64::from(self.x_shrink_factor) * u64::from(self.x_resolution_shrink_factor);
+        let width =
+            u64::from(self.reference_grid_width - self.image_area_x_offset).div_ceil(divisor);
+        width as u32
     }
 
     /// Return the overall height of the image.
     pub(crate) fn image_height(&self) -> u32 {
-        (self.reference_grid_height - self.image_area_y_offset)
-            .div_ceil(self.y_shrink_factor * self.y_resolution_shrink_factor)
+        let divisor = u64::from(self.y_shrink_factor) * u64::from(self.y_resolution_shrink_factor);
+        let height =
+            u64::from(self.reference_grid_height - self.image_area_y_offset).div_ceil(divisor);
+        height as u32
     }
 }
 
@@ -567,14 +577,6 @@ fn size_marker(reader: &mut BitReader<'_>) -> Result<SizeData> {
         if comp.precision == 0 || comp.vertical_resolution == 0 || comp.horizontal_resolution == 0 {
             bail!(ValidationError::InvalidComponentMetadata);
         }
-    }
-
-    const MAX_DIMENSIONS: usize = 60000;
-
-    if size_data.image_width() as usize > MAX_DIMENSIONS
-        || size_data.image_height() as usize > MAX_DIMENSIONS
-    {
-        bail!(ValidationError::ImageTooLarge);
     }
 
     Ok(size_data)

--- a/hayro-jpeg2000/src/j2c/decode.rs
+++ b/hayro-jpeg2000/src/j2c/decode.rs
@@ -23,7 +23,7 @@ use super::progression::{
 use super::tag_tree::TagNode;
 use super::tile::{ComponentTile, ResolutionTile, Tile};
 use super::{ComponentData, bitplane, build, idwt, mct, segment, tile};
-use crate::error::{DecodingError, Result, TileError, bail};
+use crate::error::{DecodingError, Result, TileError, ValidationError, bail};
 use crate::j2c::segment::MAX_BITPLANE_COUNT;
 use crate::math::SimdBuffer;
 use crate::reader::BitReader;
@@ -41,7 +41,7 @@ pub(crate) fn decode<'a>(
         bail!(TileError::Invalid);
     }
 
-    ctx.reset(header, &tiles[0]);
+    ctx.reset(header, &tiles[0])?;
 
     for tile in &tiles {
         trace!(
@@ -109,21 +109,23 @@ pub struct DecoderContext<'a> {
 }
 
 impl DecoderContext<'_> {
-    fn reset(&mut self, header: &Header<'_>, initial_tile: &Tile<'_>) {
+    fn reset(&mut self, header: &Header<'_>, initial_tile: &Tile<'_>) -> Result<()> {
         self.tile_decode_context.reset();
         self.storage.reset();
 
         self.channel_data.clear();
+        let sample_count = (header.size_data.image_width() as usize)
+            .checked_mul(header.size_data.image_height() as usize)
+            .ok_or(ValidationError::ImageTooLarge)?;
         // TODO: SIMD Buffers should be reused across runs!
         for info in &initial_tile.component_infos {
             self.channel_data.push(ComponentData {
-                container: SimdBuffer::zeros(
-                    header.size_data.image_width() as usize
-                        * header.size_data.image_height() as usize,
-                ),
+                container: SimdBuffer::zeros(sample_count),
                 bit_depth: info.size_info.precision,
             });
         }
+
+        Ok(())
     }
 }
 

--- a/hayro-jpeg2000/src/j2c/rect.rs
+++ b/hayro-jpeg2000/src/j2c/rect.rs
@@ -30,6 +30,10 @@ impl IntRect {
         self.y1 - self.y0
     }
 
+    pub(crate) fn area(&self) -> u64 {
+        u64::from(self.width()) * u64::from(self.height())
+    }
+
     pub(crate) fn intersect(&self, other: Self) -> Self {
         if self.x1 < other.x0 || other.x1 < self.x0 || self.y1 < other.y0 || other.y1 < self.y0 {
             Self::from_xywh(0, 0, 0, 0)

--- a/hayro-jpeg2000/src/j2c/tile.rs
+++ b/hayro-jpeg2000/src/j2c/tile.rs
@@ -79,28 +79,30 @@ impl<'a> Tile<'a> {
         let rect = {
             let size_data = &header.size_data;
 
-            let x_coord = size_data.tile_x_coord(idx);
-            let y_coord = size_data.tile_y_coord(idx);
+            let x_coord = u64::from(size_data.tile_x_coord(idx));
+            let y_coord = u64::from(size_data.tile_y_coord(idx));
 
             // See B-7, B-8, B-9 and B-10.
-            let x0 = u32::max(
-                size_data.tile_x_offset + x_coord * size_data.tile_width,
-                size_data.image_area_x_offset,
-            );
-            let y0 = u32::max(
-                size_data.tile_y_offset + y_coord * size_data.tile_height,
-                size_data.image_area_y_offset,
-            );
+            let x0 = u64::max(
+                u64::from(size_data.tile_x_offset) + x_coord * u64::from(size_data.tile_width),
+                u64::from(size_data.image_area_x_offset),
+            ) as u32;
+            let y0 = u64::max(
+                u64::from(size_data.tile_y_offset) + y_coord * u64::from(size_data.tile_height),
+                u64::from(size_data.image_area_y_offset),
+            ) as u32;
 
             // Note that `x1` and `y1` are exclusive.
-            let x1 = u32::min(
-                size_data.tile_x_offset + (x_coord + 1) * size_data.tile_width,
-                size_data.reference_grid_width,
-            );
-            let y1 = u32::min(
-                size_data.tile_y_offset + (y_coord + 1) * size_data.tile_height,
-                size_data.reference_grid_height,
-            );
+            let x1 = u64::min(
+                u64::from(size_data.tile_x_offset)
+                    + (x_coord + 1) * u64::from(size_data.tile_width),
+                u64::from(size_data.reference_grid_width),
+            ) as u32;
+            let y1 = u64::min(
+                u64::from(size_data.tile_y_offset)
+                    + (y_coord + 1) * u64::from(size_data.tile_height),
+                u64::from(size_data.reference_grid_height),
+            ) as u32;
 
             IntRect::from_ltrb(x0, y0, x1, y1)
         };
@@ -132,8 +134,9 @@ pub(crate) fn parse<'a>(
     reader: &mut BitReader<'a>,
     main_header: &'a Header<'a>,
 ) -> Result<Vec<Tile<'a>>> {
-    let mut tiles = (0..main_header.size_data.num_tiles() as usize)
-        .map(|idx| Tile::new(idx as u32, main_header))
+    let tile_count = main_header.size_data.num_tiles()?;
+    let mut tiles = (0..tile_count)
+        .map(|idx| Tile::new(idx, main_header))
         .collect::<Vec<_>>();
 
     let mut tile_part_idx = 0;
@@ -165,7 +168,7 @@ fn parse_tile_part<'a>(
 
     let tile_part_header = sot_marker(reader).ok_or(MarkerError::ParseFailure("SOT"))?;
 
-    if tile_part_header.tile_index as u32 >= main_header.size_data.num_tiles() {
+    if tile_part_header.tile_index as u32 >= main_header.size_data.num_tiles()? {
         bail!(TileError::InvalidIndex);
     }
 
@@ -799,7 +802,7 @@ mod tests {
 
         assert_eq!(size_data.num_x_tiles(), 4);
         assert_eq!(size_data.num_y_tiles(), 4);
-        assert_eq!(size_data.num_tiles(), 16);
+        assert_eq!(size_data.num_tiles().unwrap(), 16);
 
         let header = Header {
             size_data,


### PR DESCRIPTION
## Summary

Replaces the fixed 60,000-pixel-per-axis JPEG 2000 limit with checked aggregate decoded-sample limits.

The old guard rejects valid GFS Wave JPEG 2000 codestreams such as the HTSGW F000 field, which is `546_583 × 1`.

## Changes

- Keeps `Image::new` source-compatible.
- Adds `DecodeLimits` and `Image::new_with_limits`.
- Uses a 16 Mi decoded-sample default limit.
- Checks decoded component buffers, palette expansion, SIMD padding, tile count, and coefficient workspace.
- Reports oversized or unallocatable images as `ValidationError::ImageTooLarge`.

## Tests

- Adds J2C and JP2 limit coverage, including palette expansion and target-resolution paths.
- Adds the GFS Wave-derived wide-codestream regression fixture.
- Validates the downstream grib-rs decode against OpenJPEG using a temporary local Cargo patch.

`cargo test -p hayro-jpeg2000 --lib` and `cargo test -p hayro-jpeg2000 --test decoded_sample_limits` pass.

The repository asset suites could not run in this checkout because the required remote test inputs and snapshots are absent. This change does not touch those suites.

Fixes #1354

Related to https://github.com/noritada/grib-rs/issues/211