### PR TITLE
hayro-interpret: Warn when an annotation appearance cannot be resolved

### DIFF
--- a/hayro-interpret/src/interpret/mod.rs
+++ b/hayro-interpret/src/interpret/mod.rs
@@ -131,6 +131,9 @@ pub enum InterpreterWarning {
     UnsupportedFont,
     /// An image failed to decode.
     ImageDecodeFailure,
+    /// An annotation declares an `AP` entry, but no appearance stream could be
+    /// selected from it, so the annotation was not drawn.
+    UnresolvedAnnotationAppearance,
 }
 
 /// interpret the contents of the page and render them into the device.
@@ -205,6 +208,8 @@ pub fn interpret_page<'a>(
                 apx.draw(resources, context, device);
                 context.pop_root_transform();
                 context.restore_state(device);
+            } else if annot.get::<Dict<'_>>(AP).is_some() {
+                (context.settings.warning_sink)(InterpreterWarning::UnresolvedAnnotationAppearance);
             }
         }
     }


### PR DESCRIPTION
Annotations whose `AP`/`N` is a state dictionary get their stream selected through `AS`. When `AS` names a state the dictionary does not contain and there is no `Off` entry to fall back on, `appearance_stream` returns `None`, the annotation is skipped, and nothing is recorded anywhere. The widget just does not appear and the API gives the caller no way to find out why. This commit adds the missing observability for that case. It changes no rendering behaviour.

## What it does

One new variant, `InterpreterWarning::UnresolvedAnnotationAppearance`, emitted from the annotation loop in `hayro-interpret/src/interpret/mod.rs`.

The precise firing predicate is: the annotation has an `AP` entry that reads as a dictionary, and no `FormXObject` was drawn for it. That is slightly broader than "no appearance stream could be selected", because it also covers the case where a stream was selected but `FormXObject::new` could not build it. Annotations with no `AP` entry at all stay silent, since having no appearance is normal for link and popup annotations.

## What it still does not cover

Two silent skips in the same loop survive this change:

- An `AP` entry that is present but does not read as a dictionary. `annot.get::<Dict<'_>>(AP)` returns `None` for it, so the new guard does not fire.
- A missing `Rect`. That `continue` sits inside the branch that has already selected an appearance stream, so the `else if` is never reached. An annotation with a perfectly good appearance and no `Rect` is still dropped without a trace.

I left both out to keep the change to five lines, but I am happy to fold them in if you would rather have the loop fully covered in one go.

## Semver

`InterpreterWarning` is not `#[non_exhaustive]`, so adding a variant is a breaking change for downstream code that matches on it exhaustively. This is not hypothetical: it broke my own match when I pulled the branch into the editor I am building. You may well prefer to add `#[non_exhaustive]` to the enum alongside this change, or instead of it, so that future variants are additive. Tell me which you want and I will adjust the PR, including dropping the variant entirely and sending only the `#[non_exhaustive]` change if that is the more useful half.

## Tests

None in this commit. `cargo build -p hayro-interpret` is clean and `cargo test -p hayro-interpret` passes (48 tests), but nothing in the suite exercises the new warning. I did not add a fixture unprompted because the `hayro-tests` harness compares rendered output and this change produces none, so a snapshot would not actually assert the thing that matters. If you want coverage here I am glad to add it in whatever shape fits: the reproducer below is 702 bytes and would drop straight into `pdfs/custom/`, paired with a small warning-collecting assertion rather than a snapshot.

## Why this is easy to miss

<img src="https://raw.githubusercontent.com/cristim/hayro/evidence/appearance-state/hayro-before-0.7.1.png" width="480" alt="annotation_checkbox.pdf under hayro 0.7.1, four of five widgets blank" />

`hayro-tests/pdfs/custom/annotation_checkbox.pdf` rendered by released hayro 0.7.1 (the current crates.io version). Four of the five widgets are blank, and zero warnings are emitted.

<img src="https://raw.githubusercontent.com/cristim/hayro/evidence/appearance-state/hayro-after-fork.png" width="480" alt="the same file on current main, all five widgets rendering" />

The same file on current `main`. All five widgets render. To be clear about credit, that improvement is entirely yours: commit 6af63be9 from #1274, merged 2026-07-08, authored by Bela Stoyan. Nothing in this PR contributes to it. I include the pair only to explain why the observability gap is easy to overlook. The rendering half is already fixed on `main` and simply has not been released since 0.7.1 (2026-06-05), so anyone on crates.io still sees blank widgets, while the silent-skip half is still present on `main` today and is what this PR addresses.

<details>
<summary>Reproducer and verification output</summary>

`unresolved_state.pdf`, 702 bytes, hand-written. Also on the [evidence branch](https://github.com/cristim/hayro/tree/evidence/appearance-state) of my fork, along with the two images above.

```
%PDF-1.7
1 0 obj
<< /Type /Catalog /Pages 2 0 R >>
endobj
2 0 obj
<< /Type /Pages /Kids [3 0 R] /Count 1 >>
endobj
3 0 obj
<< /Type /Page /Parent 2 0 R /MediaBox [0 0 60 60] /Resources << >> /Annots [5 0 R] >>
endobj
4 0 obj
<< /Type /XObject /Subtype /Form /FormType 1 /BBox [0 0 14 14] /Resources << >> /Length 31 >>
stream
0 0 1 RG 1 w 0.5 0.5 13 13 re S
endstream
endobj
5 0 obj
<< /Type /Annot /Subtype /Widget /FT /Btn /T (missing-state) /F 4 /Rect [23 23 37 37] /AS /Nope /AP << /N << /Yes 4 0 R >> >> >>
endobj
xref
0 6
0000000000 65535 f 
0000000009 00000 n 
0000000058 00000 n 
0000000115 00000 n 
0000000217 00000 n 
0000000375 00000 n 
trailer
<< /Size 6 /Root 1 0 R >>
startxref
519
%%EOF
```

The widget's `AP`/`N` dictionary contains only `Yes`, `AS` names `Nope`, and there is no `Off` entry, so no stream can be selected. Object 4 is a valid form XObject, so the file is not otherwise broken: the annotation is skipped purely because of the state lookup.

The harness is a standalone crate with a path dependency on the hayro checkout, so the same binary can be pointed at either branch. It formats the warning with `{:?}` rather than naming the variant, so it compiles unchanged on `main`:

```rust
use hayro::hayro_syntax::Pdf;
use hayro::hayro_interpret::InterpreterSettings;
use hayro::{RenderCache, RenderSettings};
use std::sync::{Arc, Mutex};

fn main() {
    let path = std::env::args().nth(1).unwrap();
    let data = std::fs::read(&path).unwrap();
    let pdf = Pdf::new(data).unwrap();

    let warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
    let sink = warnings.clone();

    let interpreter_settings = InterpreterSettings {
        warning_sink: Arc::new(move |w| sink.lock().unwrap().push(format!("{w:?}"))),
        ..Default::default()
    };

    let cache = RenderCache::new();
    for page in pdf.pages().iter() {
        let _ = hayro::render(page, &cache, &interpreter_settings, &RenderSettings::default());
    }

    let warnings = warnings.lock().unwrap();
    println!("{}: {} warning(s)", path, warnings.len());
    for w in warnings.iter() {
        println!("  - {w}");
    }
}
```

Output, `main` at 5a5f0e24 versus this branch at 33d9caf8:

```
# main @ 5a5f0e24
$ cargo run -- unresolved_state.pdf
unresolved_state.pdf: 0 warning(s)

# this branch @ 33d9caf8
$ cargo run -- unresolved_state.pdf
unresolved_state.pdf: 1 warning(s)
  - UnresolvedAnnotationAppearance

# this branch @ 33d9caf8, checking for a false positive on the existing fixture
$ cargo run -- hayro-tests/pdfs/custom/annotation_checkbox.pdf
hayro-tests/pdfs/custom/annotation_checkbox.pdf: 0 warning(s)
```

The last one matters as much as the first: `annotation_checkbox.pdf` resolves all five of its appearances on `main`, and the new guard stays quiet on it.

</details>

## Aside, not a request

While reading the enum I noticed that `InterpreterWarning::UnsupportedFont` has no emit sites anywhere in the repository. Grepping the whole tree finds only its own declaration, so nothing ever raises it. Possibly it lost its call site in a refactor at some point. Mentioning it purely as an observation about the enum being under-used; it is not something I am asking you to act on and it is unrelated to this change.

## Attribution

I should be upfront about how this was produced. I am integrating hayro into a PDF editor I am building, hit the blank checkboxes, and had Claude (Anthropic's AI assistant) investigate. Claude found the silent skip, wrote the commit, built the reproducer and ran the verification shown above. I directed the work, reviewed the diff and every claim in this description, and I am filing it under my own name. I am flagging it because you should know what you are reviewing, and because if you would rather not take AI-assisted patches, I would much rather hear that now than have you spend time on it.
