### PR TITLE
Allow rendering an arbitrary region of a page

### DIFF
--- a/hayro/src/lib.rs
+++ b/hayro/src/lib.rs
@@ -208,11 +208,21 @@ pub struct RenderSettings {
     pub x_scale: f32,
     /// How much the contents should be scaled into the y direction.
     pub y_scale: f32,
+    /// How far the viewport should be shifted to the right, in device pixels
+    /// (i.e. after the scale factors have been applied). A value of `0.0` anchors
+    /// the viewport at the left edge of the page.
+    pub x_offset: f32,
+    /// How far the viewport should be shifted downwards, in device pixels
+    /// (i.e. after the scale factors have been applied). A value of `0.0` anchors
+    /// the viewport at the top edge of the page.
+    pub y_offset: f32,
     /// The width of the viewport. If this is set to `None`, the width will be chosen
-    /// automatically based on the scale factor and the dimensions of the PDF.
+    /// automatically based on the scale factor, the dimensions of the PDF and the
+    /// horizontal offset, so that the viewport extends to the right edge of the page.
     pub width: Option<u16>,
     /// The height of the viewport. If this is set to `None`, the height will be chosen
-    /// automatically based on the scale factor and the dimensions of the PDF.
+    /// automatically based on the scale factor, the dimensions of the PDF and the
+    /// vertical offset, so that the viewport extends to the bottom edge of the page.
     pub height: Option<u16>,
     /// The background color. Determines the color of the base
     /// rectangle during rendering to a pixmap.
@@ -224,6 +234,8 @@ impl Default for RenderSettings {
         Self {
             x_scale: 1.0,
             y_scale: 1.0,
+            x_offset: 0.0,
+            y_offset: 0.0,
             width: None,
             height: None,
             bg_color: TRANSPARENT,
@@ -239,9 +251,14 @@ pub fn render<'a>(
     render_settings: &RenderSettings,
 ) -> Pixmap {
     let (x_scale, y_scale) = (render_settings.x_scale, render_settings.y_scale);
+    let (x_offset, y_offset) = (render_settings.x_offset, render_settings.y_offset);
     let (width, height) = page.render_dimensions();
-    let (scaled_width, scaled_height) = ((width * x_scale) as f64, (height * y_scale) as f64);
-    let initial_transform = Affine::scale_non_uniform(x_scale as f64, y_scale as f64)
+    let (scaled_width, scaled_height) = (
+        (width * x_scale - x_offset).max(0.0) as f64,
+        (height * y_scale - y_offset).max(0.0) as f64,
+    );
+    let initial_transform = Affine::translate((-x_offset as f64, -y_offset as f64))
+        * Affine::scale_non_uniform(x_scale as f64, y_scale as f64)
         * page.initial_transform(true).to_kurbo();
 
     let (pix_width, pix_height) = (


### PR DESCRIPTION
`render` always anchors the device origin at the top-left corner of the page:
`initial_transform` is `scale_non_uniform(x_scale, y_scale) * page.initial_transform(true)`,
with no caller-controllable translation term. `RenderSettings::width`/`height`
size the viewport but cannot move it, so rendering a region that is not flush
with the top-left corner means rendering the whole page and cropping the
resulting `Pixmap`.

The use case is documents where only a fixed sub-region of the page carries the
information that matters — the same block, at the same relative position, across
every document of a given kind. Rendering only that region is the whole job;
producing a full-page bitmap at the DPI the region needs, only to discard most of
it, is overhead in both allocation and rasterization time.

This adds `x_offset` and `y_offset` to `RenderSettings`, in device pixels
(i.e. post-scale, so they are homogeneous with `width`/`height`), pre-multiplied
into the initial transform. Nothing else in the pipeline needed to change: the
`bbox` passed to `Context::new` is already expressed in device space, and the
crop box clip path applies `initial_transform`, so it follows the translation on
its own. When `width`/`height` are left unset, the automatic dimensions now
extend from the offset to the right and bottom edges of the page.

Both offsets default to `0.0`, which keeps current output bit-identical. The one
compatibility caveat is that adding public fields breaks exhaustive struct
literals — this may be a good moment to mark `RenderSettings` as
`#[non_exhaustive]` if you want to close that off for good.

I verified non-regression by regenerating the reference images on `main` and
re-running the suite with the patch: no pixel diff on any test whose PDF was
available locally.

Happy to change the API shape — offsets in PDF points rather than device pixels,
or a single viewport `Rect` — if you'd prefer something else. Same for tests: I
kept the diff to the feature itself since `hayro` has no tests of its own and
`hayro-tests` is snapshot-driven on assets that live outside the repo, but I can
add a module asserting that a zero offset is bit-identical to today's output and
that an offset render matches the crop of the full-page render, if that is
something you would take.

Closes #1362.
