### PR TITLE
hayro-syntax: do not decrypt a stream with a fabricated object id

### DIFF
--- a/hayro-syntax/src/object/stream.rs
+++ b/hayro-syntax/src/object/stream.rs
@@ -122,12 +122,24 @@ impl<'a> Stream<'a> {
                 .map(|t| t.as_ref() != b"XRef")
                 .unwrap_or(true)
         {
-            Cow::Owned(
-                ctx.xref()
-                    .decrypt(self.obj_id(), self.data, DecryptionTarget::Stream)
-                    // TODO: MAybe an error would be better?
-                    .unwrap_or_default(),
-            )
+            // The object id, and no substitute for it.
+            //
+            // `obj_id()` below falls back to 0 0 for a stream that carries no
+            // identifier, which a crafted PDF can produce. Handing that to
+            // `decrypt` does not fail: the per-object key is derived FROM the
+            // identifier, so a wrong identifier yields a wrong key and RC4 or
+            // AES then returns plausible bytes that are not the stream. The
+            // caller cannot tell the difference, and neither can a filter --
+            // which is worse than not decrypting at all.
+            match self.dict.obj_id() {
+                Some(obj_id) => Cow::Owned(
+                    ctx.xref()
+                        .decrypt(obj_id, self.data, DecryptionTarget::Stream)
+                        // TODO: MAybe an error would be better?
+                        .unwrap_or_default(),
+                ),
+                None => Cow::Borrowed(self.data),
+            }
         } else {
             Cow::Borrowed(self.data)
         }


### PR DESCRIPTION
`Stream::obj_id()` falls back to `ObjectIdentifier::new(0, 0)` when a stream carries no identifier, and `raw_data` hands that fallback straight to `decrypt`.

That does not fail. The per-object key is derived from the identifier, so a wrong identifier yields a wrong key, and RC4 or AES then returns plausible bytes that are not the stream. Nothing downstream can tell the difference — not the caller, not a filter — which is worse than not decrypting at all.

So `raw_data` asks the dictionary directly and returns the raw bytes when there is no identifier. `obj_id()` keeps its signature and its fallback; only the decryption path stops relying on it.

**How it turned up.** Reading a corpus of real-world encrypted PDFs, where a stream without an identifier is simply something a file can contain.

**Test.** No new test in this commit: the change is a refusal, and the only thing that would show it is a crafted file rather than an invariant. `cargo build -p hayro-syntax`, `cargo fmt --check` and `cargo clippy -p hayro-syntax` are clean. Glad to add a fixture if you would prefer one.
